### PR TITLE
[Fix] Marketplace and Collection Volume

### DIFF
--- a/crates/core/src/db/queries/stats.rs
+++ b/crates/core/src/db/queries/stats.rs
@@ -22,28 +22,20 @@ const MINT_QUERY: &str = r"
 select
     auction_house,
     mint,
-    min(listing_price) filter (where token_account_amount = 1 and listing_canceled_at is null and listing_purchase_receipt is null)::bigint as floor,
+    min(listing_price) filter (where listing_canceled_at is null and listing_purchase_receipt is null)::bigint as floor,
     round(avg(purchase_price))::bigint as average,
     sum(purchase_price) filter (where ($2 - purchased_at) < interval '24 hr')::bigint as volume_24hr
 
 from (select lr.auction_house as auction_house,
-        mc.creator_address as creator_address,
         lr.price as listing_price, pr.price as purchase_price,
         pr.created_at as purchased_at,
         lr.created_at as listed_at,
         lr.purchase_receipt as listing_purchase_receipt,
         lr.canceled_at as listing_canceled_at,
-        ta.amount as token_account_amount,
         ah.treasury_mint as mint
 from listing_receipts lr
     inner join auction_houses ah
         on (lr.auction_house = ah.address)
-    inner join metadatas md
-        on (lr.metadata = md.address)
-    inner join metadata_creators mc
-        on (md.address = mc.metadata_address)
-    inner join token_accounts ta
-        on (md.mint_address = ta.mint_address)
     left join purchase_receipts pr
         on (lr.purchase_receipt = pr.address)
 
@@ -99,7 +91,7 @@ const COLLECTION_QUERY: &str = r"
 select
     auction_house,
     mint,
-    min(listing_price) filter (where token_account_amount = 1 and listing_canceled_at is null and listing_purchase_receipt is null)::bigint as floor,
+    min(listing_price) filter (where listing_canceled_at is null and listing_purchase_receipt is null)::bigint as floor,
     round(avg(purchase_price))::bigint as average,
     sum(purchase_price) filter (where ($3 - purchased_at) < interval '24 hr')::bigint as volume_24hr
 
@@ -111,7 +103,6 @@ from (
         lr.created_at as listed_at,
         lr.purchase_receipt as listing_purchase_receipt,
         lr.canceled_at as listing_canceled_at,
-        ta.amount as token_account_amount,
         ah.treasury_mint as mint
 from listing_receipts lr
     inner join auction_houses ah
@@ -120,8 +111,6 @@ from listing_receipts lr
         on (lr.metadata = md.address)
     inner join metadata_creators mc
         on (md.address = mc.metadata_address)
-    inner join token_accounts ta
-        on (md.mint_address = ta.mint_address)
     left join purchase_receipts pr
         on (lr.purchase_receipt = pr.address)
 


### PR DESCRIPTION
## Issue

Joining token accounts was to ensure we only calculate the floor for a listing associated to the current owner of the nft. However, joining in token accounts leads to duplicate records for each of the listing receipts per the number of token accounts that once had the nft.

## Resolution
- Drop the join on token accounts which means if someone sells the nft on another exchange we won't show the listing but it will still be in our reporting.

![Screen Shot 2022-03-30 at 2 13 24 PM](https://user-images.githubusercontent.com/2388118/160933411-e10423dc-80e4-4188-b13c-95eb5c35d134.png)
