### PR TITLE
Metadata Collection addr indexing, token_standard for Metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "mpl-auction-house",
  "mpl-candy-machine",
  "mpl-metaplex",
+ "mpl-token-metadata",
  "num_cpus",
  "reqwest",
  "serde",

--- a/crates/core/diesel.toml
+++ b/crates/core/diesel.toml
@@ -6,5 +6,5 @@ file = "src/db/schema.rs"
 import_types = [
   "diesel::sql_types::*",
   "diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery}",
-  "crate::db::custom_types::{SettingType as Settingtype, Mode}",
+  "crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard}",
 ]

--- a/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/down.sql
+++ b/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/down.sql
@@ -1,3 +1,3 @@
 drop table metadata_collection_keys;
-alter table attributes drop column token_standard;
+alter table metadatas drop column token_standard;
 drop type if exists token_standard;

--- a/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/down.sql
+++ b/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/down.sql
@@ -1,0 +1,3 @@
+drop table metadata_collection_keys;
+alter table attributes drop column token_standard;
+drop type if exists token_standard;

--- a/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/up.sql
+++ b/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/up.sql
@@ -5,6 +5,12 @@ create table metadata_collection_keys (
     primary key (metadata_address, collection_address)
 );
 
+create index if not exists metadata_collection_metadata_addr on 
+metadata_collection_keys using hash (metadata_address);
+
+create index if not exists metadata_collection_collection_addr on 
+metadata_collection_keys using hash (collection_address);
+
 create type token_standard 
 as enum ('NonFungible', 'FungibleAsset', 'Fungible', 'NonFungibleEdition');
 

--- a/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/up.sql
+++ b/crates/core/migrations/2022-03-31-221314_create_table_metadata_collections_and_tokenstandard_col_for_metadatas/up.sql
@@ -1,0 +1,12 @@
+create table metadata_collection_keys (
+    metadata_address varchar(48),
+    collection_address varchar(48),
+    verified bool not null,
+    primary key (metadata_address, collection_address)
+);
+
+create type token_standard 
+as enum ('NonFungible', 'FungibleAsset', 'Fungible', 'NonFungibleEdition');
+
+alter table metadatas
+add column token_standard token_standard null;

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -13,11 +13,11 @@ use super::schema::{
     candy_machine_datas, candy_machine_end_settings, candy_machine_gate_keeper_configs,
     candy_machine_hidden_settings, candy_machine_whitelist_mint_settings, candy_machines, editions,
     files, graph_connections, listing_metadatas, listing_receipts, master_editions,
-    metadata_collections, metadata_creators, metadata_jsons, metadatas, purchase_receipts,
-    store_config_jsons, store_configs, store_creators, storefronts, stores, token_accounts,
-    twitter_handle_name_services, whitelisted_creators,
+    metadata_collection_keys, metadata_collections, metadata_creators, metadata_jsons, metadatas,
+    purchase_receipts, store_config_jsons, store_configs, store_creators, storefronts, stores,
+    token_accounts, twitter_handle_name_services, whitelisted_creators,
 };
-use crate::db::custom_types::{EndSettingType, WhitelistMintMode};
+use crate::db::custom_types::{EndSettingType, TokenStandardEnum, WhitelistMintMode};
 
 /// A row in the `bids` table
 #[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Associations)]
@@ -200,6 +200,8 @@ pub struct Metadata<'a> {
     pub edition_nonce: Option<i32>,
     /// edition pda derived from account
     pub edition_pda: Cow<'a, str>,
+    /// Type of NFT token
+    pub token_standard: Option<TokenStandardEnum>,
 }
 
 /// A row in the `storefronts` table
@@ -847,4 +849,17 @@ pub struct TwitterHandle<'a> {
     pub twitter_handle: Cow<'a, str>,
     /// Solana slot number
     pub slot: i64,
+}
+
+/// A row in the `metadata_collection_keys` table
+/// Each collection is an NFT
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+#[diesel(treat_none_as_null = true)]
+pub struct MetadataCollectionKey<'a> {
+    /// Metadata address
+    pub metadata_address: Cow<'a, str>,
+    /// Collection Address
+    pub collection_address: Cow<'a, str>,
+    /// Whether the collection is verified or not.
+    pub verified: bool,
 }

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -1,7 +1,7 @@
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     attributes (id) {
         metadata_address -> Varchar,
@@ -15,7 +15,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     auction_caches (address) {
         address -> Varchar,
@@ -31,7 +31,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     auction_datas (address) {
         address -> Varchar,
@@ -50,7 +50,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     auction_datas_ext (address) {
         address -> Varchar,
@@ -63,7 +63,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     auction_houses (address) {
         address -> Varchar,
@@ -86,7 +86,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     bid_receipts (address) {
         address -> Varchar,
@@ -109,7 +109,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     bids (listing_address, bidder_address) {
         listing_address -> Varchar,
@@ -123,7 +123,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_collection_pdas (address) {
         address -> Varchar,
@@ -135,7 +135,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_config_lines (address) {
         address -> Varchar,
@@ -147,7 +147,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_creators (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -160,7 +160,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_datas (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -179,7 +179,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_end_settings (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -191,7 +191,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_gate_keeper_configs (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -203,7 +203,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_hidden_settings (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -216,7 +216,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machine_whitelist_mint_settings (candy_machine_address) {
         candy_machine_address -> Varchar,
@@ -230,7 +230,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     candy_machines (address) {
         address -> Varchar,
@@ -244,7 +244,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     editions (address) {
         address -> Varchar,
@@ -256,7 +256,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     files (id) {
         metadata_address -> Varchar,
@@ -269,7 +269,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     graph_connections (address) {
         address -> Varchar,
@@ -281,7 +281,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     listing_denylist (listing_address) {
         listing_address -> Varchar,
@@ -292,7 +292,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     listing_metadatas (listing_address, metadata_address) {
         listing_address -> Varchar,
@@ -304,7 +304,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     listing_receipts (address) {
         address -> Varchar,
@@ -326,7 +326,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     master_editions (address) {
         address -> Varchar,
@@ -338,7 +338,19 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
+
+    metadata_collection_keys (metadata_address, collection_address) {
+        metadata_address -> Varchar,
+        collection_address -> Varchar,
+        verified -> Bool,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     metadata_collections (id) {
         metadata_address -> Varchar,
@@ -351,7 +363,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     metadata_creators (metadata_address, creator_address) {
         metadata_address -> Varchar,
@@ -365,7 +377,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     metadata_jsons (metadata_address) {
         metadata_address -> Varchar,
@@ -384,7 +396,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     metadatas (address) {
         address -> Varchar,
@@ -398,13 +410,14 @@ table! {
         is_mutable -> Bool,
         edition_nonce -> Nullable<Int4>,
         edition_pda -> Varchar,
+        token_standard -> Nullable<Token_standard>,
     }
 }
 
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     purchase_receipts (address) {
         address -> Varchar,
@@ -423,7 +436,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     store_config_jsons (config_address) {
         config_address -> Varchar,
@@ -441,7 +454,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     store_configs (address) {
         address -> Varchar,
@@ -452,7 +465,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     store_creators (store_config_address, creator_address) {
         store_config_address -> Varchar,
@@ -463,7 +476,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     store_denylist (owner_address) {
         owner_address -> Varchar,
@@ -474,7 +487,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     storefronts (address) {
         owner_address -> Varchar,
@@ -493,7 +506,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     stores (address) {
         address -> Varchar,
@@ -505,7 +518,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     token_accounts (address) {
         address -> Varchar,
@@ -520,7 +533,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     twitter_handle_name_services (address) {
         address -> Varchar,
@@ -533,7 +546,7 @@ table! {
 table! {
     use diesel::sql_types::*;
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
-    use crate::db::custom_types::{SettingType as Settingtype, Mode};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
     whitelisted_creators (address) {
         address -> Varchar,
@@ -566,6 +579,7 @@ allow_tables_to_appear_in_same_query!(
     listing_metadatas,
     listing_receipts,
     master_editions,
+    metadata_collection_keys,
     metadata_collections,
     metadata_creators,
     metadata_jsons,

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -59,6 +59,7 @@ anchor-lang-v0-21-0 = { package = "anchor-lang", version = "0.21.0" }
 metaplex = { version="0.0.1", features = ["no-entrypoint"] }
 metaplex-auction = { version="0.0.1", features = ["no-entrypoint"] }
 metaplex-token-metadata = { version="0.0.1", features = ["no-entrypoint"] }
+mpl-token-metadata = { version="1.2.4", features = ["no-entrypoint"] }
 metaplex-token-vault = { version="0.0.1", features = ["no-entrypoint"] }
 mpl-auction-house = { version="1.1.0", features = ["no-entrypoint"] }
 mpl-candy-machine = { version="~3.1.1", features = ["no-entrypoint"] }

--- a/crates/indexer/src/geyser/accounts/edition.rs
+++ b/crates/indexer/src/geyser/accounts/edition.rs
@@ -3,7 +3,7 @@ use indexer_core::db::{
     models::{Edition, MasterEdition},
     tables::{editions, master_editions},
 };
-use metaplex_token_metadata::state::{
+use mpl_token_metadata::state::{
     Edition as EditionAccount, MasterEdition as MasterEditionTrait,
     MasterEditionV2 as MasterEditionV2Account,
 };

--- a/crates/indexer/src/geyser/accounts/metadata.rs
+++ b/crates/indexer/src/geyser/accounts/metadata.rs
@@ -13,9 +13,6 @@ use super::Client;
 use crate::prelude::*;
 
 pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount) -> Result<()> {
-    if meta.collection.is_some() {
-        dbg!("{:?}", &meta);
-    }
     let addr = bs58::encode(key).into_string();
     let (edition_pda_key, _bump) = find_edition(meta.mint);
     let row = Metadata {

--- a/crates/indexer/src/geyser/accounts/metadata.rs
+++ b/crates/indexer/src/geyser/accounts/metadata.rs
@@ -1,17 +1,21 @@
 use indexer_core::{
     db::{
+        custom_types::TokenStandardEnum,
         insert_into,
-        models::{Metadata, MetadataCreator},
-        tables::{metadata_creators, metadatas},
+        models::{Metadata, MetadataCollectionKey, MetadataCreator},
+        tables::{metadata_collection_keys, metadata_creators, metadatas},
     },
     pubkeys::find_edition,
 };
-use metaplex_token_metadata::state::Metadata as MetadataAccount;
+use mpl_token_metadata::state::{Collection, Metadata as MetadataAccount, TokenStandard};
 
 use super::Client;
 use crate::prelude::*;
 
 pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount) -> Result<()> {
+    if meta.collection.is_some() {
+        dbg!("{:?}", &meta);
+    }
     let addr = bs58::encode(key).into_string();
     let (edition_pda_key, _bump) = find_edition(meta.mint);
     let row = Metadata {
@@ -26,6 +30,12 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
         is_mutable: meta.is_mutable,
         edition_nonce: meta.edition_nonce.map(Into::into),
         edition_pda: Owned(bs58::encode(edition_pda_key).into_string()),
+        token_standard: meta.token_standard.map(|ts| match ts {
+            TokenStandard::NonFungible => TokenStandardEnum::NonFungible,
+            TokenStandard::FungibleAsset => TokenStandardEnum::FungibleAsset,
+            TokenStandard::Fungible => TokenStandardEnum::Fungible,
+            TokenStandard::NonFungibleEdition => TokenStandardEnum::NonFungibleEdition,
+        }),
     };
     let first_verified_creator: Option<Pubkey> = meta
         .data
@@ -84,6 +94,40 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
             .await
             .context("Failed to insert metadata creator")?;
     }
+
+    if meta.collection.is_some() {
+        index_metadata_collection_key(client, addr, meta.collection.context("err!")?).await?;
+    }
+
+    Ok(())
+}
+
+async fn index_metadata_collection_key(
+    client: &Client,
+    addr: String,
+    collection: Collection,
+) -> Result<()> {
+    let row = MetadataCollectionKey {
+        metadata_address: Owned(addr),
+        collection_address: Owned(collection.key.to_string()),
+        verified: collection.verified,
+    };
+
+    client
+        .db()
+        .run(move |db| {
+            insert_into(metadata_collection_keys::table)
+                .values(&row)
+                .on_conflict((
+                    metadata_collection_keys::metadata_address,
+                    metadata_collection_keys::collection_address,
+                ))
+                .do_update()
+                .set(&row)
+                .execute(db)
+        })
+        .await
+        .context("Failed to insert into metadata_collection_keys")?;
 
     Ok(())
 }

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -1,11 +1,11 @@
 //! Miscellaneous utility functions.
 #![allow(dead_code)]
 
-use metaplex_token_metadata::state::{MasterEditionV1, MasterEditionV2};
+use mpl_token_metadata::state::{MasterEditionV1, MasterEditionV2};
 #[cfg(feature = "solana-program")]
 use {
     indexer_core::prelude::*,
-    metaplex_token_metadata::state::Key,
+    mpl_token_metadata::state::Key,
     solana_program::{account_info::AccountInfo, entrypoint::ProgramResult},
     solana_sdk::{account::Account, pubkey::Pubkey},
 };
@@ -98,7 +98,7 @@ impl MasterEdition {
 }
 
 #[cfg(feature = "solana-program")]
-impl metaplex_token_metadata::state::MasterEdition for MasterEdition {
+impl mpl_token_metadata::state::MasterEdition for MasterEdition {
     fn key(&self) -> Key {
         match self {
             Self::V1(m) => m.key(),


### PR DESCRIPTION
- deserialize metadata account using mpl-token-metadata first and if it fails then using metaplex-token-metadata
- indexes collection address
- adds token_standard to metadata


A collection is an NFT in v1.1.0 of the token metadata standard so the collection information is already indexed in metadatas table 