### PR TITLE
Query Graph Connection Enriched with Twitter Profile

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -855,6 +855,26 @@ pub struct MintStats<'a> {
     pub volume_24hr: Option<i64>,
 }
 
+/// A join of `graph_connections` and `twitter_handle_name_services` for connections that include twitter handle of wallets
+#[derive(Debug, Clone, QueryableByName)]
+pub struct TwitterEnrichedGraphConnection {
+    /// The address of the connection
+    #[sql_type = "VarChar"]
+    pub connection_address: String,
+    /// The from_account of the connection
+    #[sql_type = "VarChar"]
+    pub from_account: String,
+    /// The to_account of the connection
+    #[sql_type = "VarChar"]
+    pub to_account: String,
+    /// The twitter handle of the from_account
+    #[sql_type = "Nullable<Text>"]
+    pub from_twitter_handle: Option<String>,
+    /// The twitter handle of the to_account
+    #[sql_type = "Nullable<Text>"]
+    pub to_twitter_handle: Option<String>,
+}
+
 /// A row in a `metadatas::count_by_marketplace` query, representing stats for
 /// a single marketplace
 #[derive(Debug, Clone, QueryableByName)]

--- a/crates/core/src/db/queries/graph_connection.rs
+++ b/crates/core/src/db/queries/graph_connection.rs
@@ -1,0 +1,48 @@
+//! Query utilities for `graph_connections` table.
+
+use diesel::{
+    pg::Pg,
+    serialize::ToSql,
+    sql_query,
+    sql_types::{Array, Int4, Text},
+};
+
+use crate::{
+    db::{models::TwitterEnrichedGraphConnection, Connection},
+    error::Result,
+    prelude::*,
+};
+
+const CONNECTIONS_QUERY: &str = r"
+SELECT gc.address AS connection_address, from_account, to_account, fth.twitter_handle AS from_twitter_handle, tth.twitter_handle AS to_twitter_handle
+    FROM graph_connections gc
+    LEFT JOIN twitter_handle_name_services fth ON gc.from_account = fth.wallet_address
+    LEFT JOIN twitter_handle_name_services tth ON gc.to_account = tth.wallet_address
+    WHERE ($1 = '{}' OR from_account = ANY($1)) AND ($2 = '{}' OR to_account = ANY($2))
+    ORDER BY connection_address
+    LIMIT $3 OFFSET $4;
+ -- $1: from::text[]
+ -- $2: to::text[]
+ -- $3: limit::integer
+ -- $4: limit::integer
+ ";
+
+/// Return connections based on from and to filters with limits and offset
+///
+/// # Errors
+/// This function fails if the underlying query fails to execute.
+pub fn list(
+    conn: &Connection,
+    from: impl ToSql<Array<Text>, Pg>,
+    to: impl ToSql<Array<Text>, Pg>,
+    limit: impl ToSql<Int4, Pg>,
+    offset: impl ToSql<Int4, Pg>,
+) -> Result<Vec<TwitterEnrichedGraphConnection>> {
+    sql_query(CONNECTIONS_QUERY)
+        .bind(from)
+        .bind(to)
+        .bind(limit)
+        .bind(offset)
+        .load(conn)
+        .context("failed to load twitter enriched graph connections")
+}

--- a/crates/core/src/db/queries/mod.rs
+++ b/crates/core/src/db/queries/mod.rs
@@ -1,7 +1,9 @@
 //! Reusable query operations for common or complicated queries.
 
+pub mod graph_connection;
 pub mod listing_denylist;
 pub mod metadata_edition;
 pub mod metadatas;
 pub mod stats;
 pub mod store_denylist;
+pub mod twitter_handle_name_service;

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -1,0 +1,22 @@
+//! Query utilities for `graph_connections` table.
+
+use diesel::OptionalExtension;
+
+use crate::{
+    db::{tables::twitter_handle_name_services, Connection},
+    error::Result,
+    prelude::*,
+};
+
+/// Return twitter handle linked to the provide wallet address
+///
+/// # Errors
+/// This function fails if the underlying query fails to execute.
+pub fn get(conn: &Connection, address: String) -> Result<Option<String>> {
+    twitter_handle_name_services::table
+        .filter(twitter_handle_name_services::wallet_address.eq(address))
+        .select(twitter_handle_name_services::twitter_handle)
+        .first::<String>(conn)
+        .optional()
+        .context("Failed to load twitter handle")
+}

--- a/crates/graphql/src/schema/objects/graph_connection.rs
+++ b/crates/graphql/src/schema/objects/graph_connection.rs
@@ -1,0 +1,46 @@
+use indexer_core::db::models;
+use objects::wallet::Wallet;
+
+use super::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct GraphConnection {
+    pub address: String,
+    pub from: Wallet,
+    pub to: Wallet,
+}
+
+#[graphql_object(Context = AppContext)]
+impl GraphConnection {
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub fn from(&self) -> &Wallet {
+        &self.from
+    }
+
+    pub fn to(&self) -> &Wallet {
+        &self.to
+    }
+}
+
+impl TryFrom<models::TwitterEnrichedGraphConnection> for GraphConnection {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(
+        models::TwitterEnrichedGraphConnection {
+            connection_address,
+            from_account,
+            to_account,
+            from_twitter_handle,
+            to_twitter_handle,
+        }: models::TwitterEnrichedGraphConnection,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address: connection_address,
+            from: Wallet::new(from_account, from_twitter_handle),
+            to: Wallet::new(to_account, to_twitter_handle),
+        })
+    }
+}

--- a/crates/graphql/src/schema/objects/mod.rs
+++ b/crates/graphql/src/schema/objects/mod.rs
@@ -2,6 +2,7 @@ pub mod auction_house;
 pub mod bid_receipt;
 pub mod creator;
 pub mod denylist;
+pub mod graph_connection;
 pub mod listing;
 pub mod listing_receipt;
 pub mod marketplace;

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -3,6 +3,7 @@ use objects::{
     auction_house::AuctionHouse,
     creator::Creator,
     denylist::Denylist,
+    graph_connection::GraphConnection,
     listing::{Listing, ListingColumns, ListingRow},
     marketplace::Marketplace,
     nft::Nft,
@@ -75,12 +76,57 @@ impl QueryRoot {
         )))
     }
 
+    fn connections(
+        &self,
+        context: &AppContext,
+        #[graphql(description = "Connections from a list of wallets")] from: Option<
+            Vec<PublicKey<Wallet>>,
+        >,
+        #[graphql(description = "Connections to a list of wallets")] to: Option<
+            Vec<PublicKey<Wallet>>,
+        >,
+        #[graphql(description = "Query limit")] limit: i32,
+        #[graphql(description = "Query offset")] offset: i32,
+    ) -> FieldResult<Vec<GraphConnection>> {
+        if from.is_none() && to.is_none() {
+            return Err(FieldError::new(
+                "No filter provided! Please provide at least one of the filters",
+                graphql_value!({ "Filters": "from: Vec<PublicKey>, to: Vec<PublicKey>" }),
+            ));
+        }
+        let conn = context.db_pool.get().context("failed to connect to db")?;
+        let from: Vec<String> = from
+            .unwrap_or_else(Vec::new)
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let to: Vec<String> = to
+            .unwrap_or_else(Vec::new)
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        let rows = queries::graph_connection::list(&conn, from, to, limit, offset)?;
+
+        rows.into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)
+    }
+
     fn creator(
         &self,
-        _context: &AppContext,
+        context: &AppContext,
         #[graphql(description = "Address of creator")] address: String,
-    ) -> Creator {
-        Creator { address }
+    ) -> FieldResult<Creator> {
+        let conn = context.db_pool.get().context("failed to connect to db")?;
+
+        let twitter_handle = queries::twitter_handle_name_service::get(&conn, address.clone())?;
+
+        Ok(Creator {
+            address,
+            twitter_handle,
+        })
     }
 
     fn nfts(
@@ -123,10 +169,14 @@ impl QueryRoot {
 
     fn wallet(
         &self,
-        _context: &AppContext,
-        #[graphql(description = "Address of NFT")] address: String,
-    ) -> Option<Wallet> {
-        Some(Wallet { address })
+        context: &AppContext,
+        #[graphql(description = "Address of the wallet")] address: String,
+    ) -> FieldResult<Wallet> {
+        let conn = context.db_pool.get()?;
+
+        let twitter_handle = queries::twitter_handle_name_service::get(&conn, address.clone())?;
+
+        Ok(Wallet::new(address, twitter_handle))
     }
 
     fn listings(&self, context: &AppContext) -> FieldResult<Vec<Listing>> {


### PR DESCRIPTION
### Goals

Clients can query graph connections and have access to twitter info of the wallet when linked with bonfida.

### Changes
- Add root query for `connections(from, to, limit, offset)`
- wallet and creator root queries include profile when linked