### PR TITLE
remove duplicate attributes

### DIFF
--- a/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/down.sql
+++ b/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/down.sql
@@ -1,2 +1,9 @@
 alter table attributes 
-drop constraint attributes_unique_constraint;
+drop constraint if exists attributes_unique_constraint;
+
+alter table attributes
+drop constraint if exists attributes_primary_key_constraint;
+
+drop table attributes;
+
+alter table temp_attributes rename to attributes;

--- a/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/down.sql
+++ b/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/down.sql
@@ -1,0 +1,2 @@
+alter table attributes 
+drop constraint attributes_unique_constraint;

--- a/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
+++ b/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
@@ -1,0 +1,15 @@
+create table temp as
+    select distinct on (metadata_address,value,trait_type) * from attributes;
+
+alter table attributes
+    drop constraint if exists attributes_unique_constraint,
+    drop constraint if exists attributes_primary_key_constraint;
+
+alter table temp
+    add constraint attributes_unique_constraint unique (metadata_address, value, trait_type),
+    add constraint attributes_primary_key_constraint primary key (id),
+    alter column metadata_address set not null,
+    alter column id set default gen_random_uuid();
+
+drop table attributes;
+alter table temp rename to attributes;

--- a/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
+++ b/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
@@ -11,5 +11,5 @@ alter table temp
     alter column metadata_address set not null,
     alter column id set default gen_random_uuid();
 
-drop table attributes;
+alter table attributes rename to temp_attributes;
 alter table temp rename to attributes;

--- a/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
+++ b/crates/core/migrations/2022-04-07-154737_remove_duplicate_attributes/up.sql
@@ -1,5 +1,5 @@
 create table temp as
-    select distinct on (metadata_address,value,trait_type) * from attributes;
+    select distinct on (metadata_address, value, trait_type) * from attributes;
 
 alter table attributes
     drop constraint if exists attributes_unique_constraint,

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -768,6 +768,20 @@ table! {
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
     use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
 
+    temp_attributes (id) {
+        metadata_address -> Varchar,
+        value -> Nullable<Text>,
+        trait_type -> Nullable<Text>,
+        id -> Uuid,
+        first_verified_creator -> Nullable<Varchar>,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
+    use crate::db::custom_types::{SettingType as Settingtype, Mode, TokenStandard as Token_standard};
+
     token_accounts (address) {
         address -> Varchar,
         mint_address -> Varchar,
@@ -916,6 +930,7 @@ allow_tables_to_appear_in_same_query!(
     storefronts,
     stores,
     sub_account_infos,
+    temp_attributes,
     token_accounts,
     transactions,
     twitter_handle_name_services,

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -401,6 +401,7 @@ fn process_attributes(
                 attributes::value,
                 attributes::trait_type,
             ))
+            .do_update()
             .set(&row)
             .execute(db)
             .context("Failed to insert attribute!")?;

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -396,7 +396,12 @@ fn process_attributes(
 
         insert_into(attributes::table)
             .values(&row)
-            .on_conflict_do_nothing()
+            .on_conflict((
+                attributes::metadata_address,
+                attributes::value,
+                attributes::trait_type,
+            ))
+            .set(&row)
             .execute(db)
             .context("Failed to insert attribute!")?;
     }


### PR DESCRIPTION
Attributes table has no unique constraint on (metadata_address, value, trait_type) because these fields are optional so we can not use primary key constraint on them.

So, a temp table is created which contains only distinct rows from attributes table and has a UNIQUE constraint on (metadata_address, value, trait_type) . The attributes table is renamed to temp_attributes and the temp table is then renamed to attributes