### PR TITLE
Add workflow to trigger docs site rebuild

### DIFF
--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dispatch:
-    -name: Dispatch event to docs repo
+    - name: Dispatch event to docs repo
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -3,7 +3,7 @@ name: Send event to rebuild docs
 on:
   push:
     branches:
-      - main
+      - [dev, master]
 
 jobs:
   dispatch:

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -1,0 +1,16 @@
+name: Let docs know to update.
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    -name: Dispatch msg to docs repo
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
+        repository: holaplex/marketplace-api-docs
+        event-type: api_update
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -2,8 +2,7 @@ name: Send event to rebuild docs
 
 on:
   push:
-    branches:
-      - [dev, master]
+    branches: [dev, master]
 
 jobs:
   dispatch:

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -13,4 +13,4 @@ jobs:
         token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
         repository: holaplex/marketplace-api-docs
         event-type: api_update
-        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   dispatch:
-    - name: Dispatch event to docs repo
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
-        repository: holaplex/marketplace-api-docs
-        event-type: api_update
-        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch event to docs repo
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
+          repository: holaplex/marketplace-api-docs
+          event-type: api_update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/dispatch_to_docs.yml
+++ b/.github/workflows/dispatch_to_docs.yml
@@ -1,4 +1,4 @@
-name: Let docs know to update.
+name: Send event to rebuild docs
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dispatch:
-    -name: Dispatch msg to docs repo
+    -name: Dispatch event to docs repo
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
Add workflow that sends a `dispatch_event` to `holaplex/marketplace-api-docs` which causes a site rebuild and refresh with the new API details.