### PR TITLE
dont let one unparseable image url ruin the whole batch

### DIFF
--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -275,22 +275,19 @@ Any other value will return the original image size.
 
 If no value is provided, it will return XSmall")))]
     pub fn image(&self, width: Option<i32>, ctx: &AppContext) -> FieldResult<String> {
+        let id = if let Ok(url) = Url::parse(&self.image) {
+            AssetIdentifier::new(&url)
+        } else {
+            return Ok(self.image.clone());
+        };
+
         let width = ImageSize::from(width.unwrap_or(ImageSize::XSmall as i32));
         let width_str = (width as i32).to_string();
 
-        Ok(Url::parse(&self.image)
-            .and_then(|url| Ok(AssetIdentifier::new(&url)))
-            .map(|asset_id| {
-                proxy_url(
-                    &ctx.shared.asset_proxy,
-                    &asset_id,
-                    Some(("width", &*width_str)),
-                )
-            })
-            .map_or_else(
-                |_url| self.image.clone(),
-                |u| u.ok().flatten().unwrap().to_string(),
-            ))
+        Ok(
+            proxy_url(&ctx.shared.asset_proxy, &id, Some(("width", &*width_str)))?
+                .map_or_else(|| self.image.clone(), |u| u.to_string()),
+        )
     }
 
     pub async fn creators(&self, ctx: &AppContext) -> FieldResult<Vec<NftCreator>> {


### PR DESCRIPTION
If we can't parse an image url, let it go to the frontend unchanged, as it is on the NFT.