### PR TITLE
[Fix] Adding constraints to events tables

### DIFF
--- a/crates/core/migrations/2022-04-11-135022_create_feed_event_tables/up.sql
+++ b/crates/core/migrations/2022-04-11-135022_create_feed_event_tables/up.sql
@@ -26,9 +26,11 @@ create table offer_events (
   lifecycle offereventlifecycle  not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (bid_receipt_address) references bid_receipts (address),
-  constraint uc_offer_events_bid_receipt_address_lifecycle UNIQUE (bid_receipt_address, lifecycle)
+  foreign key (bid_receipt_address) references bid_receipts (address)
 );
+
+alter table offer_events 
+  add constraint uc_offer_events_bid_receipt_address_lifecycle UNIQUE (bid_receipt_address, lifecycle);
 
 create type listingeventlifecycle as ENUM('Created', 'Cancelled');
 
@@ -38,9 +40,11 @@ create table listing_events (
   lifecycle listingeventlifecycle not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (listing_receipt_address) references listing_receipts (address),
-  constraint uc_listing_events_listing_receipt_address_lifecycle UNIQUE (listing_receipt_address, lifecycle)
+  foreign key (listing_receipt_address) references listing_receipts (address)
 );
+
+alter table listing_events
+  add constraint uc_listing_events_listing_receipt_address_lifecycle UNIQUE (listing_receipt_address, lifecycle);
 
 create table purchase_events (
   purchase_receipt_address varchar(48) not null unique,


### PR DESCRIPTION
Migrations failing with the below error. Adjusting how constraints are added to the tables.

```
2022-04-26T13:02:44.805343+00:00 app[worker.1]: [2022-04-26T13:02:44Z INFO  holaplex_indexer_core::db] Running database migrations...
2022-04-26T13:02:44.850119+00:00 app[worker.1]: [2022-04-26T13:02:44Z ERROR holaplex_indexer_core] Failed to connect to Postgres
2022-04-26T13:02:44.850121+00:00 app[worker.1]:     
2022-04-26T13:02:44.850121+00:00 app[worker.1]:     Caused by:
2022-04-26T13:02:44.850121+00:00 app[worker.1]:         0: Failed to run database migrations
2022-04-26T13:02:44.850122+00:00 app[worker.1]:         1: Failed with: constraints on permanent tables may reference only permanent tables
```