### PR TITLE
Fix[Feed Events]: Move constraints into another migration file

### DIFF
--- a/crates/core/migrations/2022-04-11-135022_create_feed_event_tables/up.sql
+++ b/crates/core/migrations/2022-04-11-135022_create_feed_event_tables/up.sql
@@ -24,8 +24,7 @@ create table offer_events (
   lifecycle text check (lifecycle IN ('Created', 'Cancelled')) not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (bid_receipt_address) references bid_receipts (address),
-  constraint uc_offer_events_bid_receipt_address_lifecycle UNIQUE (bid_receipt_address, lifecycle)
+  foreign key (bid_receipt_address) references bid_receipts (address)
 );
 
 create table listing_events (
@@ -34,8 +33,7 @@ create table listing_events (
   lifecycle text check (lifecycle IN ('Created', 'Cancelled')) not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (listing_receipt_address) references listing_receipts (address),
-  constraint uc_listing_events_listing_receipt_address_lifecycle UNIQUE (listing_receipt_address, lifecycle)
+  foreign key (listing_receipt_address) references listing_receipts (address)
 );
 
 create table purchase_events (

--- a/crates/core/migrations/2022-04-26-165439_add_feed_event_tables_constraints/down.sql
+++ b/crates/core/migrations/2022-04-26-165439_add_feed_event_tables_constraints/down.sql
@@ -1,0 +1,5 @@
+alter table offer_events
+  drop constraint uc_offer_events_bid_receipt_address_lifecycle;
+
+alter table listing_events
+  drop constraint uc_listing_events_listing_receipt_address_lifecycle;

--- a/crates/core/migrations/2022-04-26-165439_add_feed_event_tables_constraints/up.sql
+++ b/crates/core/migrations/2022-04-26-165439_add_feed_event_tables_constraints/up.sql
@@ -1,0 +1,5 @@
+alter table offer_events
+  add constraint uc_offer_events_bid_receipt_address_lifecycle UNIQUE (bid_receipt_address, lifecycle);
+
+alter table listing_events
+  add constraint uc_listing_events_listing_receipt_address_lifecycle UNIQUE (listing_receipt_address, lifecycle);


### PR DESCRIPTION
### Changes
Add constraints for tables in another migration so table created before constraints added.