### PR TITLE
Fix[Feed Events]: Use constraint instead of foreign key for metadatas

### DIFF
--- a/crates/core/migrations/2022-04-26-183109_create_mint_events_table/up.sql
+++ b/crates/core/migrations/2022-04-26-183109_create_mint_events_table/up.sql
@@ -3,7 +3,7 @@ create table mint_events (
   feed_event_id uuid not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (metadata_address) references metadatas (address)
+  constraint uc_mint_events_metadata_address unique (metadata_address)
 );
 
 create index if not exists mint_events_metadata_address_idx on 

--- a/crates/core/migrations/2022-04-26-183118_create_offer_events_table/down.sql
+++ b/crates/core/migrations/2022-04-26-183118_create_offer_events_table/down.sql
@@ -1,4 +1,3 @@
 drop table offer_events;
 drop index if exists offer_events_bid_receipt_address_idx;
 drop type if exists offereventlifecycle;
-

--- a/crates/core/migrations/2022-04-26-183132_create_purchase_events_table/up.sql
+++ b/crates/core/migrations/2022-04-26-183132_create_purchase_events_table/up.sql
@@ -3,7 +3,8 @@ create table purchase_events (
   feed_event_id uuid not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (purchase_receipt_address) references purchase_receipts (address)
+  foreign key (purchase_receipt_address) references purchase_receipts (address),
+  constraint uc_purchase_events_purchase_receipt_address unique (purchase_receipt_address)
 );
 
 create index if not exists purchase_events_purchase_receipt_address_idx on 

--- a/crates/core/migrations/2022-04-26-183139_create_follow_events_table/up.sql
+++ b/crates/core/migrations/2022-04-26-183139_create_follow_events_table/up.sql
@@ -3,7 +3,8 @@ create table follow_events (
   feed_event_id uuid not null,
   primary key (feed_event_id),
   foreign key (feed_event_id) references feed_events (id),
-  foreign key (graph_connection_address) references graph_connections (address)
+  foreign key (graph_connection_address) references graph_connections (address),
+  constraint uc_follow_events_graph_connection_address unique (graph_connection_address)
 );
 
 create index if not exists follow_events_graph_connection_address_idx on 

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -1138,7 +1138,6 @@ joinable!(follow_events -> graph_connections (graph_connection_address));
 joinable!(listing_events -> feed_events (feed_event_id));
 joinable!(listing_events -> listing_receipts (listing_receipt_address));
 joinable!(mint_events -> feed_events (feed_event_id));
-joinable!(mint_events -> metadatas (metadata_address));
 joinable!(offer_events -> bid_receipts (bid_receipt_address));
 joinable!(offer_events -> feed_events (feed_event_id));
 joinable!(purchase_events -> feed_events (feed_event_id));


### PR DESCRIPTION
### Changes
- Use unique constraint instead of foreign key to enforce uniqueness.