### PR TITLE
[Fix] Select model from sample nft quert

### DIFF
--- a/crates/graphql/src/schema/dataloaders/collection.rs
+++ b/crates/graphql/src/schema/dataloaders/collection.rs
@@ -16,7 +16,17 @@ impl TryBatchFn<PublicKey<StoreCreator>, Vec<Nft>> for Batcher {
         let conn = self.db()?;
 
         let rows: Vec<models::SampleNft> = sql_query(
-                "SELECT sample_metadatas.creator_address, sample_metadatas.address, sample_metadatas.name, sample_metadatas.seller_fee_basis_points, sample_metadatas.mint_address, sample_metadatas.primary_sale_happened, sample_metadatas.uri, sample_metadatas.description, sample_metadatas.image, sample_metadatas.category
+                "SELECT sample_metadatas.creator_address,
+                    sample_metadatas.address,
+                    sample_metadatas.name,
+                    sample_metadatas.seller_fee_basis_points,
+                    sample_metadatas.mint_address,
+                    sample_metadatas.primary_sale_happened,
+                    sample_metadatas.uri,
+                    sample_metadatas.description,
+                    sample_metadatas.image,
+                    sample_metadatas.category,
+                    sample_metadatas.model
                 FROM store_creators
                 JOIN LATERAL (
                     SELECT


### PR DESCRIPTION
## Issue
The model column was add to the nft object but it wasn't selected for sample metadatas query.