### PR TITLE
[Fix] NFTs Query Order by Listed

### DIFF
--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -251,7 +251,9 @@ impl QueryRoot {
             Vec<PublicKey<Wallet>>,
         >,
         #[graphql(description = "Filter on attributes")] attributes: Option<Vec<AttributeFilter>>,
-        #[graphql(description = "Filter on listed")] listed: Option<Vec<PublicKey<AuctionHouse>>>,
+        #[graphql(description = "Filter only listed nfts")] listed: Option<bool>,
+        #[graphql(description = "Filter nfts associated to the list of auction houses")]
+        auction_houses: Option<Vec<PublicKey<AuctionHouse>>>,
         #[graphql(description = "Filter on a collection")] collection: Option<PublicKey<Nft>>,
         #[graphql(description = "Limit for query")] limit: i32,
         #[graphql(description = "Offset for query")] offset: i32,
@@ -259,12 +261,12 @@ impl QueryRoot {
         if collection.is_none()
             && owners.is_none()
             && creators.is_none()
-            && listed.is_none()
+            && auction_houses.is_none()
             && offerers.is_none()
         {
             return Err(FieldError::new(
                 "No filter provided! Please provide at least one of the filters",
-                graphql_value!({ "Filters": "owners: Vec<PublicKey>, creators: Vec<PublicKey>, offerers: Vec<PublicKey>, listed: Vec<PublicKey>" }),
+                graphql_value!({ "Filters": "owners: Vec<PublicKey>, creators: Vec<PublicKey>, offerers: Vec<PublicKey>, auction_houses: Vec<PublicKey>" }),
             ));
         }
 
@@ -275,7 +277,8 @@ impl QueryRoot {
             creators: creators.map(|a| a.into_iter().map(Into::into).collect()),
             offerers: offerers.map(|a| a.into_iter().map(Into::into).collect()),
             attributes: attributes.map(|a| a.into_iter().map(Into::into).collect()),
-            listed: listed.map(|a| a.into_iter().map(Into::into).collect()),
+            listed,
+            auction_houses: auction_houses.map(|a| a.into_iter().map(Into::into).collect()),
             collection: collection.map(Into::into),
             limit: limit.into(),
             offset: offset.into(),

--- a/crates/indexer/src/geyser/accounts/metadata.rs
+++ b/crates/indexer/src/geyser/accounts/metadata.rs
@@ -80,8 +80,7 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
                         metadata_creators::creator_address,
                     ))
                     .do_update()
-                    // TODO: why aren't we setting other fields here??
-                    .set(metadata_creators::verified.eq(row.verified))
+                    .set(&row)
                     .execute(db)
                     .context("failed to insert metadata creators")?;
 


### PR DESCRIPTION
## Issue
Without passing in the auction house of the marketplace nfts are returned that aren't listed on the marketplace. The frontend filtered out these listings but they still show in the results but without the listed status.

## Changes
- Caller of nfts field always able to set auction_houses to scope results by.
- `listed` change to a boolean.


<img width="1177" alt="Screen Shot 2022-05-02 at 1 05 47 PM" src="https://user-images.githubusercontent.com/2388118/166224517-95a12312-5509-4a0d-95ba-f98f96bed1a7.png">
