### PR TITLE
[Fix] Twitter Loader Response Ordering

### DIFF
--- a/crates/graphql/src/schema/dataloaders/wallet.rs
+++ b/crates/graphql/src/schema/dataloaders/wallet.rs
@@ -48,7 +48,7 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
                 Ok(users) => {
                     Either::Left(users.into_iter().map(|u| (u.screen_name.clone(), Ok(u))))
                 },
-                Err(e) => Either::Right(keys.iter().map(move |key| (key.clone(), Err(e.clone())))),
+                Err(e) => Either::Right(keys.iter().cloned().zip(std::iter::repeat(Err(e)))),
             })
             .map(|(k, user)| {
                 (

--- a/crates/graphql/src/schema/dataloaders/wallet.rs
+++ b/crates/graphql/src/schema/dataloaders/wallet.rs
@@ -45,13 +45,10 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
             .into_iter()
             .zip(chunked_screen_names)
             .flat_map(|(result, keys)| match result {
-                Ok(users) => Either::Left(
-                    users
-                        .into_iter()
-                        .zip(keys)
-                        .map(|(user, key)| (key, Ok(user))),
-                ),
-                Err(e) => Either::Right(keys.iter().map(move |key| (key, Err(e.clone())))),
+                Ok(users) => {
+                    Either::Left(users.into_iter().map(|u| (u.screen_name.clone(), Ok(u))))
+                },
+                Err(e) => Either::Right(keys.iter().map(move |key| (key.clone(), Err(e.clone())))),
             })
             .map(|(k, user)| {
                 (

--- a/crates/graphql/src/schema/objects/profile.rs
+++ b/crates/graphql/src/schema/objects/profile.rs
@@ -37,24 +37,24 @@ impl From<TwitterUserProfileResponse> for TwitterProfile {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TwitterProfilePictureResponse {
     pub data: TwitterProfilePicture,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TwitterProfilePicture {
     pub profile_image_url: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TwitterShowResponse {
     pub screen_name: String,
     pub profile_image_url_https: String,
     pub profile_banner_url: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TwitterUserProfileResponse {
     pub screen_name: String,
     pub description: String,


### PR DESCRIPTION
### Issue

The order of the profiles returned isnt guarnteed to be the same as the list of screen names passed to the call.

```
The order of user IDs or screen names may not match the order of users in the returned array.
If a requested user is unknown, suspended, or deleted, then that user will not be returned in the results list.
```

https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup

### Fix

Figure out users to return based on the users  list and not keys.