### PR TITLE
holaplex-#347: add field for number of created NFTs to followWallets query

### DIFF
--- a/crates/core/src/db/queries/nft_count.rs
+++ b/crates/core/src/db/queries/nft_count.rs
@@ -117,6 +117,38 @@ where
         .context("failed to load owned nfts count")
 }
 
+/// Handles queries for created nfts count
+///
+/// # Errors
+/// returns an error when the underlying queries throw an error
+pub fn created<W: AsExpression<Text>, C: ToSql<Text, Pg>>(
+    conn: &Connection,
+    wallet: W,
+) -> Result<i64>
+where
+    W::Expression: NonAggregate
+        + QueryFragment<Pg>
+        + AppearsOnTable<
+            JoinOn<
+                Join<metadatas::table, metadata_creators::table, Inner>,
+                Eq<metadatas::address, metadata_creators::metadata_address>,
+            >,
+        >,
+{
+    let mut query = metadatas::table
+        .inner_join(
+            metadata_creators::table.on(metadatas::address.eq(metadata_creators::metadata_address)),
+        )
+        .into_boxed();
+
+    query
+        .filter(metadata_creators::verified.eq(true))
+        .filter(metadata_creators::creator_address.eq(wallet))
+        .count()
+        .get_result(conn)
+        .context("failed to load created nfts count")
+}
+
 /// Handles queries for nfts count for a wallet with optional creators and auction house filters
 ///
 /// # Errors

--- a/crates/core/src/db/queries/nft_count.rs
+++ b/crates/core/src/db/queries/nft_count.rs
@@ -121,7 +121,7 @@ where
 ///
 /// # Errors
 /// returns an error when the underlying queries throw an error
-pub fn created<W: AsExpression<Text>, C: ToSql<Text, Pg>>(
+pub fn created<W: AsExpression<Text>>(
     conn: &Connection,
     wallet: W,
 ) -> Result<i64>
@@ -135,7 +135,7 @@ where
             >,
         >,
 {
-    let mut query = metadatas::table
+    let query = metadatas::table
         .inner_join(
             metadata_creators::table.on(metadatas::address.eq(metadata_creators::metadata_address)),
         )

--- a/crates/core/src/db/queries/nft_count.rs
+++ b/crates/core/src/db/queries/nft_count.rs
@@ -121,10 +121,7 @@ where
 ///
 /// # Errors
 /// returns an error when the underlying queries throw an error
-pub fn created<W: AsExpression<Text>>(
-    conn: &Connection,
-    wallet: W,
-) -> Result<i64>
+pub fn created<W: AsExpression<Text>>(conn: &Connection, wallet: W) -> Result<i64>
 where
     W::Expression: NonAggregate
         + QueryFragment<Pg>

--- a/crates/graphql/src/schema/objects/wallet.rs
+++ b/crates/graphql/src/schema/objects/wallet.rs
@@ -109,6 +109,14 @@ impl WalletNftCount {
 
         Ok(count.try_into()?)
     }
+
+    fn created(&self, context: &AppContext) -> FieldResult<i32> {
+        let conn = context.shared.db.get()?;
+
+        let count = queries::nft_count::created(&conn, &self.wallet)?;
+
+        Ok(count.try_into()?)
+    }
 }
 
 #[graphql_object(Context = AppContext)]


### PR DESCRIPTION
This PR adds a count for the number of NFTs created by the current wallet.

# Changes
- added db query to count the number of NFTs for which the current wallet is one of the creators (`nft_count.rs`)
- added `created` field to `WalletNftCount`, pulling stat from above query

# Preview
![image](https://user-images.githubusercontent.com/1540936/167956192-81dfd2a5-0ed3-4872-a8ca-e2d0786d13b3.png)

required for https://github.com/holaplex/holaplex/issues/347