### PR TITLE
Fix-up NFTs Query Accuracy and Improve Performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,8 +1993,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -2012,12 +2022,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.1",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -2576,7 +2611,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730788801b3fc91d9f97095e3590239f7078d81c8c1e9a35460898a806c0b24d"
 dependencies = [
- "anchor-lang 0.22.1",
+ "anchor-lang 0.24.2",
  "anchor-spl 0.22.1",
  "num-traits",
  "smart-wallet 0.9.0",
@@ -2796,6 +2831,10 @@ dependencies = [
  "meilisearch-sdk",
  "num_cpus",
  "rand 0.8.5",
+ "sea-query",
+ "sea-query-attr",
+ "sea-query-derive",
+ "sea-query-driver",
  "serde_json",
  "solana-sdk",
  "strum 0.24.0",
@@ -3319,7 +3358,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f5e4241760b2efb99e1d8a12e33cebd53f85ac4af093f804891517cd98a952b"
 dependencies = [
- "anchor-lang 0.22.1",
+ "anchor-lang 0.24.2",
  "anchor-spl 0.22.1",
  "govern",
  "num-traits",
@@ -4108,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
@@ -4139,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -4513,6 +4552,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-query"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0fa62db5ae33dfc61e805b0b0c9d579c3733f1ed90326b3779f5b38f30fa2a"
+dependencies = [
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-attr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878cf3d57f0e5bfacd425cdaccc58b4c06d68a7b71c63fc28710a20c88676808"
+dependencies = [
+ "darling 0.14.1",
+ "heck 0.4.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cdc022b4f606353fe5dc85b09713a04e433323b70163e81513b141c6ae6eb5"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-query-driver"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3953baee94dcb90f0e19e8b4b91b91e9394867b0fc1886d0221cfc6d0439f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,7 +4695,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling",
+ "darling 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -5355,9 +5439,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730788801b3fc91d9f97095e3590239f7078d81c8c1e9a35460898a806c0b24d"
 dependencies = [
- "anchor-lang 0.24.2",
+ "anchor-lang 0.22.1",
  "anchor-spl 0.22.1",
  "num-traits",
  "smart-wallet 0.9.0",
@@ -3358,7 +3358,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f5e4241760b2efb99e1d8a12e33cebd53f85ac4af093f804891517cd98a952b"
 dependencies = [
- "anchor-lang 0.24.2",
+ "anchor-lang 0.22.1",
  "anchor-spl 0.22.1",
  "govern",
  "num-traits",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -43,6 +43,10 @@ meilisearch-sdk = { version = "0.15.0", optional = true }
 num_cpus = "1.13.1"
 rand = "0.8.4"
 serde_json = "1.0.70"
+sea-query = "0.24.6"
+sea-query-derive = "0.2.0"
+sea-query-attr = "0.1.1"
+sea-query-driver = "0.1.1"
 strum = { version = "0.24.0", features = ["derive"] }
 uuid = "0.8.2"
 

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -16,7 +16,6 @@ use crate::{
         Connection,
     },
     error::prelude::*,
-    prelude::*,
 };
 
 /// Format for incoming filters on attributes
@@ -100,7 +99,6 @@ enum MetadataCollectionKeys {
     Table,
     MetadataAddress,
     CollectionAddress,
-    Verified,
 }
 
 /// List query options
@@ -286,7 +284,7 @@ pub fn list(
     }
 
     if let Some(attributes) = attributes {
-        for AttributeFilter { trait_type, values } in attributes.into_iter() {
+        for AttributeFilter { trait_type, values } in attributes {
             let alias = format!("attributes_{}", trait_type);
             let alias: DynIden = SeaRc::new(Alias::new(&alias));
 

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -1,25 +1,24 @@
 //! Query utilities for looking up  metadatas
-
 use diesel::{
     pg::Pg,
     prelude::*,
     serialize::ToSql,
     sql_types::{Array, Text},
 };
+use sea_query::{
+    Alias, Condition, DynIden, Expr, Iden, JoinType, Order, PostgresQueryBuilder, Query, SeaRc,
+};
 
 use crate::{
     db::{
-        any,
         models::{Nft, NftActivity},
-        not,
-        tables::{
-            attributes, bid_receipts, current_metadata_owners, listing_receipts,
-            metadata_collection_keys, metadata_creators, metadata_jsons, metadatas,
-        },
+        tables::{metadata_jsons, metadatas},
         Connection,
     },
     error::prelude::*,
+    prelude::*,
 };
+
 /// Format for incoming filters on attributes
 #[derive(Debug)]
 pub struct AttributeFilter {
@@ -27,6 +26,81 @@ pub struct AttributeFilter {
     pub trait_type: String,
     /// array of trait values
     pub values: Vec<String>,
+}
+
+#[derive(Iden)]
+enum Metadatas {
+    Table,
+    Address,
+    Name,
+    MintAddress,
+    PrimarySaleHappened,
+    SellerFeeBasisPoints,
+    Uri,
+}
+
+#[derive(Iden)]
+enum MetadataJsons {
+    Table,
+    MetadataAddress,
+    Description,
+    Image,
+    Category,
+    Model,
+}
+
+#[derive(Iden)]
+enum CurrentMetadataOwners {
+    Table,
+    OwnerAddress,
+    MintAddress,
+}
+
+#[derive(Iden)]
+enum ListingReceipts {
+    Table,
+    Price,
+    Metadata,
+    AuctionHouse,
+    Seller,
+    PurchaseReceipt,
+    CanceledAt,
+}
+
+#[derive(Iden)]
+enum MetadataCreators {
+    Table,
+    CreatorAddress,
+    MetadataAddress,
+    Verified,
+}
+
+#[derive(Iden)]
+
+enum BidReceipts {
+    Table,
+    Buyer,
+    Price,
+    Metadata,
+    CanceledAt,
+    PurchaseReceipt,
+    AuctionHouse,
+}
+
+#[derive(Iden)]
+enum Attributes {
+    Table,
+    MetadataAddress,
+    TraitType,
+    Value,
+}
+
+#[derive(Iden)]
+enum MetadataCollectionKeys {
+    Table,
+    MetadataAddress,
+    CollectionAddress,
+    Verified,
 }
 
 /// List query options
@@ -47,9 +121,9 @@ pub struct ListQueryOptions {
     /// nft in a specific colleciton
     pub collection: Option<String>,
     /// limit to apply to query
-    pub limit: i64,
+    pub limit: u64,
     /// offset to apply to query
-    pub offset: i64,
+    pub offset: u64,
 }
 
 /// The column set for an NFT
@@ -85,87 +159,176 @@ pub fn list(
         offset,
     }: ListQueryOptions,
 ) -> Result<Vec<Nft>> {
-    let listed = listed.unwrap_or(false);
+    let mut listing_receipts_query = Query::select()
+        .columns(vec![
+            (ListingReceipts::Table, ListingReceipts::Metadata),
+            (ListingReceipts::Table, ListingReceipts::Price),
+            (ListingReceipts::Table, ListingReceipts::Seller),
+        ])
+        .from(ListingReceipts::Table)
+        .order_by(
+            (ListingReceipts::Table, ListingReceipts::Price),
+            Order::Desc,
+        )
+        .and_where(Expr::tbl(ListingReceipts::Table, ListingReceipts::PurchaseReceipt).is_null())
+        .and_where(Expr::tbl(ListingReceipts::Table, ListingReceipts::CanceledAt).is_null())
+        .take();
 
-    let mut query = metadatas::table
-        .inner_join(
-            metadata_creators::table.on(metadatas::address.eq(metadata_creators::metadata_address)),
-        )
-        .inner_join(
-            metadata_jsons::table.on(metadatas::address.eq(metadata_jsons::metadata_address)),
-        )
-        .inner_join(
-            current_metadata_owners::table
-                .on(metadatas::mint_address.eq(current_metadata_owners::mint_address)),
-        )
-        .left_outer_join(
-            listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)),
-        )
-        .left_outer_join(bid_receipts::table.on(metadatas::address.eq(bid_receipts::metadata)))
-        .left_outer_join(
-            metadata_collection_keys::table
-                .on(metadatas::address.eq(metadata_collection_keys::metadata_address)),
-        )
-        .distinct()
-        .select((NftColumns::default(), listing_receipts::price.nullable()))
-        .order_by((listing_receipts::price.asc(), metadatas::name.asc()))
-        .into_boxed();
-
-    if let Some(auction_houses) = auction_houses {
-        query = query.filter(listing_receipts::auction_house.eq(any(auction_houses)));
-        query = query.or_filter(listing_receipts::auction_house.is_null());
+    if let Some(auction_houses) = auction_houses.clone() {
+        listing_receipts_query.and_where(
+            Expr::col((ListingReceipts::Table, ListingReceipts::AuctionHouse))
+                .is_in(auction_houses),
+        );
     }
 
-    if let Some(attributes) = attributes {
-        query =
-            attributes
-                .into_iter()
-                .fold(query, |acc, AttributeFilter { trait_type, values }| {
-                    let sub = attributes::table
-                        .select(attributes::metadata_address)
-                        .filter(
-                            attributes::trait_type
-                                .eq(trait_type)
-                                .and(attributes::value.eq(any(values))),
-                        );
+    let mut query = Query::select()
+        .columns(vec![
+            (Metadatas::Table, Metadatas::Address),
+            (Metadatas::Table, Metadatas::Name),
+            (Metadatas::Table, Metadatas::SellerFeeBasisPoints),
+            (Metadatas::Table, Metadatas::MintAddress),
+            (Metadatas::Table, Metadatas::PrimarySaleHappened),
+            (Metadatas::Table, Metadatas::Uri),
+        ])
+        .columns(vec![
+            (MetadataJsons::Table, MetadataJsons::Description),
+            (MetadataJsons::Table, MetadataJsons::Image),
+            (MetadataJsons::Table, MetadataJsons::Category),
+            (MetadataJsons::Table, MetadataJsons::Model),
+        ])
+        .from(MetadataJsons::Table)
+        .inner_join(
+            Metadatas::Table,
+            Expr::tbl(MetadataJsons::Table, MetadataJsons::MetadataAddress)
+                .equals(Metadatas::Table, Metadatas::Address),
+        )
+        .inner_join(
+            CurrentMetadataOwners::Table,
+            Expr::tbl(Metadatas::Table, Metadatas::MintAddress).equals(
+                CurrentMetadataOwners::Table,
+                CurrentMetadataOwners::MintAddress,
+            ),
+        )
+        .inner_join(
+            MetadataCreators::Table,
+            Expr::tbl(Metadatas::Table, Metadatas::Address)
+                .equals(MetadataCreators::Table, MetadataCreators::MetadataAddress),
+        )
+        .join_lateral(
+            JoinType::LeftJoin,
+            listing_receipts_query.take(),
+            ListingReceipts::Table,
+            Condition::all()
+                .add(
+                    Expr::tbl(ListingReceipts::Table, ListingReceipts::Metadata)
+                        .equals(Metadatas::Table, Metadatas::Address),
+                )
+                .add(
+                    Expr::tbl(ListingReceipts::Table, ListingReceipts::Seller).equals(
+                        CurrentMetadataOwners::Table,
+                        CurrentMetadataOwners::OwnerAddress,
+                    ),
+                ),
+        )
+        .and_where(Expr::tbl(MetadataCreators::Table, MetadataCreators::Verified).eq(true))
+        .limit(limit)
+        .offset(offset)
+        .order_by((ListingReceipts::Table, ListingReceipts::Price), Order::Asc)
+        .take();
 
-                    acc.filter(metadatas::address.eq(any(sub)))
-                });
+    if let Some(owners) = owners {
+        query.and_where(Expr::col(CurrentMetadataOwners::OwnerAddress).is_in(owners));
     }
 
     if let Some(creators) = creators {
-        query = query.filter(metadata_creators::creator_address.eq(any(creators)));
-        query = query.filter(metadata_creators::verified.eq(true));
+        query.and_where(Expr::col(MetadataCreators::CreatorAddress).is_in(creators));
     }
 
-    if let Some(collection) = collection {
-        query = query.filter(metadata_collection_keys::collection_address.eq(collection));
-    }
-
-    if let Some(owners) = owners {
-        query = query.filter(current_metadata_owners::owner_address.eq(any(owners)));
+    if let Some(listed) = listed {
+        query.conditions(
+            listed,
+            |q| {
+                q.and_where(
+                    Expr::col((ListingReceipts::Table, ListingReceipts::Price)).is_not_null(),
+                );
+            },
+            |q| {
+                q.and_where(Expr::col((ListingReceipts::Table, ListingReceipts::Price)).is_null());
+            },
+        );
     }
 
     if let Some(offerers) = offerers {
-        query = query
-            .filter(bid_receipts::buyer.eq(any(offerers)))
-            .filter(bid_receipts::purchase_receipt.is_null())
-            .filter(bid_receipts::canceled_at.is_null());
+        let mut bid_receipts_query = Query::select()
+            .columns(vec![
+                (BidReceipts::Table, BidReceipts::Metadata),
+                (BidReceipts::Table, BidReceipts::Price),
+            ])
+            .from(BidReceipts::Table)
+            .and_where(Expr::col((BidReceipts::Table, BidReceipts::Buyer)).is_in(offerers))
+            .and_where(Expr::tbl(BidReceipts::Table, BidReceipts::PurchaseReceipt).is_null())
+            .and_where(Expr::tbl(BidReceipts::Table, BidReceipts::CanceledAt).is_null())
+            .take();
+
+        if let Some(auction_houses) = auction_houses {
+            bid_receipts_query.and_where(
+                Expr::col((BidReceipts::Table, BidReceipts::AuctionHouse)).is_in(auction_houses),
+            );
+        }
+
+        query.join_lateral(
+            JoinType::InnerJoin,
+            bid_receipts_query.take(),
+            BidReceipts::Table,
+            Expr::tbl(BidReceipts::Table, BidReceipts::Metadata)
+                .equals(Metadatas::Table, Metadatas::Address),
+        );
     }
 
-    if listed {
-        query = query.filter(not(listing_receipts::price.is_null()));
+    if let Some(attributes) = attributes {
+        for AttributeFilter { trait_type, values } in attributes.into_iter() {
+            let alias = format!("attributes_{}", trait_type);
+            let alias: DynIden = SeaRc::new(Alias::new(&alias));
+
+            query.join_lateral(
+                JoinType::InnerJoin,
+                Query::select()
+                    .from(Attributes::Table)
+                    .column((Attributes::Table, Attributes::MetadataAddress))
+                    .and_where(Expr::col(Attributes::TraitType).eq(trait_type))
+                    .and_where(Expr::col(Attributes::Value).is_in(values))
+                    .take(),
+                alias.clone(),
+                Expr::tbl(alias, Attributes::MetadataAddress)
+                    .equals(Metadatas::Table, Metadatas::Address),
+            );
+        }
     }
 
-    let rows: Vec<(Nft, Option<i64>)> = query
-        .filter(listing_receipts::purchase_receipt.is_null())
-        .filter(listing_receipts::canceled_at.is_null())
-        .limit(limit)
-        .offset(offset)
+    if let Some(collection) = collection {
+        query.inner_join(
+            MetadataCollectionKeys::Table,
+            Expr::tbl(
+                MetadataCollectionKeys::Table,
+                MetadataCollectionKeys::MetadataAddress,
+            )
+            .equals(Metadatas::Table, Metadatas::Address),
+        );
+
+        query.and_where(
+            Expr::col((
+                MetadataCollectionKeys::Table,
+                MetadataCollectionKeys::CollectionAddress,
+            ))
+            .eq(collection),
+        );
+    }
+
+    let query = query.to_string(PostgresQueryBuilder);
+
+    diesel::sql_query(query)
         .load(conn)
-        .context("failed to load nft(s)")?;
-
-    Ok(rows.into_iter().map(|(nft, _)| nft).collect())
+        .context("Failed to load nft(s)")
 }
 
 const ACTIVITES_QUERY: &str = r"

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -335,8 +335,8 @@ impl QueryRoot {
             listed,
             auction_houses: auction_houses.map(|a| a.into_iter().map(Into::into).collect()),
             collection: collection.map(Into::into),
-            limit: limit.into(),
-            offset: offset.into(),
+            limit: limit.try_into()?,
+            offset: offset.try_into()?,
         };
         let nfts = queries::metadatas::list(&conn, query_options)?;
 


### PR DESCRIPTION
### Changes
- Add sea-query as a dependency to the core package.
- Convert the nfts query to use sea-query to form the query but still execute and deserialize with diesel.
- Fix up total counts for listed by filtering out listings that don't belong to the current owner of the metadata. This protects against listing on Holaplex but selling on another exchange. (In the future we should present clean actions to the user to close out dangling listings).
