### PR TITLE
holaplex/#350: add queries/stats for mint rate and purchase rate

### DIFF
--- a/crates/core/src/db/queries/mod.rs
+++ b/crates/core/src/db/queries/mod.rs
@@ -10,5 +10,6 @@ pub mod metadata_edition;
 pub mod metadatas;
 pub mod nft_count;
 pub mod stats;
+pub mod stats_global;
 pub mod store_denylist;
 pub mod twitter_handle_name_service;

--- a/crates/core/src/db/queries/stats_global.rs
+++ b/crates/core/src/db/queries/stats_global.rs
@@ -1,0 +1,46 @@
+//! Query utilities for global stats
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+use crate::{
+    db::{
+        tables::{feed_events, mint_events, purchase_events},
+        Connection,
+    },
+    error::prelude::*,
+};
+
+/// Return date of ith most recent mint
+///
+/// # Errors
+/// This function fails if the underlying query fails to execute.
+pub fn nth_mint_date(conn: &Connection, i: Option<u32>) -> Result<Vec<NaiveDateTime>> {
+    let offset: u32 = i.unwrap_or(1000);
+
+    feed_events::table
+        .inner_join(mint_events::table.on(feed_events::id.eq(mint_events::feed_event_id)))
+        .select(feed_events::created_at)
+        .order(feed_events::created_at.desc())
+        .limit(1)
+        .offset(offset.try_into()?)
+        .load(conn)
+        .context("Failed to load recent mint")
+}
+
+/// Return date of ith most recent purchase
+///
+/// # Errors
+/// This function fails if the underlying query fails to execute.
+pub fn nth_purchase_date(conn: &Connection, i: Option<u32>) -> Result<Vec<NaiveDateTime>> {
+    let offset: u32 = i.unwrap_or(1000);
+
+    feed_events::table
+        .inner_join(purchase_events::table.on(feed_events::id.eq(purchase_events::feed_event_id)))
+        .select(feed_events::created_at)
+        .order(feed_events::created_at.desc())
+        .limit(1)
+        .offset(offset.try_into()?)
+        .load(conn)
+        .context("Failed to load recent mint")
+}

--- a/crates/graphql/src/main.rs
+++ b/crates/graphql/src/main.rs
@@ -8,6 +8,7 @@
     missing_copy_implementations
 )]
 #![warn(clippy::pedantic, clippy::cargo, missing_docs)]
+#![feature(lint_reasons)]
 
 use std::sync::Arc;
 

--- a/crates/graphql/src/schema/objects/mod.rs
+++ b/crates/graphql/src/schema/objects/mod.rs
@@ -13,6 +13,7 @@ pub mod nft;
 pub mod profile;
 pub mod purchase_receipt;
 pub mod stats;
+pub mod stats_global;
 pub mod store_creator;
 pub mod storefront;
 pub mod wallet;

--- a/crates/graphql/src/schema/objects/stats_global.rs
+++ b/crates/graphql/src/schema/objects/stats_global.rs
@@ -1,0 +1,10 @@
+use super::prelude::*;
+
+#[derive(Debug, Clone, GraphQLObject)]
+pub struct GlobalStats {
+    #[graphql(description = "Approximate number of NFTs being minted per second.")]
+    pub mint_rate: Option<f64>,
+
+    #[graphql(description = "Approximate number of NFTs being bought from listings per second.")]
+    pub purchase_rate: Option<f64>,
+}


### PR DESCRIPTION
This PR adds queries and a gql endpoint for approximate NFT mint rate and approximate NFT/listing purchase rate to be used in the new homepage.

Start in `query_root.rs`

# Main Changes
- added db query for ith (1000th) most recently minted NFT to compute approximate mint rate (`**/queries/stats_global.rs`, `**/queries/mod.rs`)
- added db query for ith (1000th) most recently purchased NFT to compute approximate purchase rate (`**/queries/stats_global.rs`, `**/queries/mod.rs`)
- added global stats object to be returned by global stats gql query (`**/objects/stats_global.rs`, `**/objects/mod.rs`)
- added gql root query to do db query and calculate mint and purchase rates (`query_root.rs`)

# Other Changes
- allow for `lint_reasons` (i.e. reason for allowing/denying/warning a particular lint rule) to explain downcast (`main.rs`)


blocks https://github.com/holaplex/holaplex/issues/345
blocks https://github.com/holaplex/holaplex/issues/350