### PR TITLE
Mpw/moving twitter req to cdn

### DIFF
--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -203,7 +203,7 @@ mod cdn {
     pub struct AssetProxyArgs {
         /// Endpoint for Holaplex asset CDN
         #[clap(long, env)]
-        asset_proxy_endpoint: String,
+        pub asset_proxy_endpoint: String,
 
         /// Number of replicas available to proxy asset requests to
         #[clap(long, env)]

--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -203,7 +203,7 @@ mod cdn {
     pub struct AssetProxyArgs {
         /// Endpoint for Holaplex asset CDN
         #[clap(long, env)]
-        pub asset_proxy_endpoint: String,
+        asset_proxy_endpoint: String,
 
         /// Number of replicas available to proxy asset requests to
         #[clap(long, env)]
@@ -283,6 +283,26 @@ mod cdn {
                 .map(Some)
             },
         }
+    }
+
+    /// Get the base URL for proxied Twitter handle requests
+    ///
+    /// # Errors
+    /// This function fails if the asset proxy configured by `args` has an
+    /// invalid URL
+    #[inline]
+    pub fn proxy_twitter_handle_url(
+        args: &AssetProxyArgs,
+        screen_name: impl AsRef<str>,
+    ) -> Result<Url> {
+        let mut url = Url::parse(&args.asset_proxy_endpoint.replace("[n]", ""))
+            .context("Invalid asset proxy URL")?;
+
+        url.path_segments_mut()
+            .unwrap_or_else(|_| unreachable!())
+            .extend(["twitter", screen_name.as_ref()]);
+
+        Ok(url)
     }
 
     /// Format an [`AssetIdentifier`] as an Holaplex asset proxy URL.  Returns

--- a/crates/graphql/src/schema/context.rs
+++ b/crates/graphql/src/schema/context.rs
@@ -52,10 +52,7 @@ impl juniper::Context for AppContext {}
 impl AppContext {
     pub(crate) fn new(shared: Arc<SharedData>) -> AppContext {
         let batcher = Batcher::new(shared.db.clone());
-        let twitter_batcher = TwitterBatcher::new(
-            shared.asset_proxy.asset_proxy_endpoint.clone(),
-            shared.twitter_bearer_token.clone(),
-        );
+        let twitter_batcher = TwitterBatcher::new(shared.clone());
 
         Self {
             auction_house_loader: Loader::new(batcher.clone()),

--- a/crates/graphql/src/schema/context.rs
+++ b/crates/graphql/src/schema/context.rs
@@ -52,7 +52,10 @@ impl juniper::Context for AppContext {}
 impl AppContext {
     pub(crate) fn new(shared: Arc<SharedData>) -> AppContext {
         let batcher = Batcher::new(shared.db.clone());
-        let twitter_batcher = TwitterBatcher::new(shared.twitter_bearer_token.clone());
+        let twitter_batcher = TwitterBatcher::new(
+            shared.asset_proxy.asset_proxy_endpoint.clone(),
+            shared.twitter_bearer_token.clone(),
+        );
 
         Self {
             auction_house_loader: Loader::new(batcher.clone()),

--- a/crates/graphql/src/schema/dataloaders/batcher.rs
+++ b/crates/graphql/src/schema/dataloaders/batcher.rs
@@ -119,8 +119,8 @@ pub struct Batcher(Arc<Pool>);
 
 #[derive(Clone)]
 pub struct TwitterBatcher {
-    bearer: String,
     endpoint: String,
+    bearer: String,
 }
 
 impl Batcher {
@@ -139,7 +139,7 @@ impl TwitterBatcher {
     pub fn new(endpoint: String, bearer: String) -> Self {
         Self { endpoint, bearer }
     }
-
+    // Saving this for when we add a bearer_token for the assets_cdn
     pub fn bearer(&self) -> &str {
         &self.bearer
     }

--- a/crates/graphql/src/schema/dataloaders/batcher.rs
+++ b/crates/graphql/src/schema/dataloaders/batcher.rs
@@ -120,6 +120,7 @@ pub struct Batcher(Arc<Pool>);
 #[derive(Clone)]
 pub struct TwitterBatcher {
     bearer: String,
+    endpoint: String,
 }
 
 impl Batcher {
@@ -135,12 +136,15 @@ impl Batcher {
 
 impl TwitterBatcher {
     #[must_use]
-    pub fn new(bearer: String) -> Self {
-        Self { bearer }
+    pub fn new(endpoint: String, bearer: String) -> Self {
+        Self { endpoint, bearer }
     }
 
     pub fn bearer(&self) -> &str {
         &self.bearer
+    }
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
     }
 }
 

--- a/crates/graphql/src/schema/dataloaders/batcher.rs
+++ b/crates/graphql/src/schema/dataloaders/batcher.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, hash::Hash, sync::Arc};
 
+use indexer_core::assets::proxy_twitter_handle_url;
+use reqwest::Url;
+
 use super::prelude::*;
+use crate::SharedData;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum Error {
@@ -119,13 +123,12 @@ pub struct Batcher(Arc<Pool>);
 
 #[derive(Clone)]
 pub struct TwitterBatcher {
-    endpoint: String,
-    bearer: String,
+    shared: Arc<SharedData>,
 }
 
 impl Batcher {
     #[must_use]
-    pub fn new(pool: Arc<Pool>) -> Self {
+    pub(crate) fn new(pool: Arc<Pool>) -> Self {
         Self(pool)
     }
 
@@ -136,15 +139,18 @@ impl Batcher {
 
 impl TwitterBatcher {
     #[must_use]
-    pub fn new(endpoint: String, bearer: String) -> Self {
-        Self { endpoint, bearer }
+    pub(crate) fn new(shared: Arc<SharedData>) -> Self {
+        Self { shared }
     }
-    // Saving this for when we add a bearer_token for the assets_cdn
+
+    #[inline]
     pub fn bearer(&self) -> &str {
-        &self.bearer
+        &self.shared.twitter_bearer_token
     }
-    pub fn endpoint(&self) -> &str {
-        &self.endpoint
+
+    #[inline]
+    pub fn proxy_url(&self, screen_name: impl AsRef<str>) -> Result<Url> {
+        proxy_twitter_handle_url(&self.shared.asset_proxy, screen_name)
     }
 }
 

--- a/crates/graphql/src/schema/dataloaders/wallet.rs
+++ b/crates/graphql/src/schema/dataloaders/wallet.rs
@@ -16,10 +16,11 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
             .map(|screen_name| {
                 let http_client = &http_client;
                 let _ = self.bearer();
-                let endpoint = self.endpoint().replace("[n]", "");
+                let url = self.proxy_url(screen_name);
+
                 async move {
                     http_client
-                        .get(format!("{}twitter/{}", endpoint, screen_name))
+                        .get(url.map_err(Error::model_convert)?)
                         .header("Accept", "application/json")
                         .send()
                         .await

--- a/crates/graphql/src/schema/dataloaders/wallet.rs
+++ b/crates/graphql/src/schema/dataloaders/wallet.rs
@@ -12,15 +12,11 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
         let http_client = reqwest::Client::new();
 
         let twitter_users = screen_names
-            .into_iter()
+            .iter()
             .map(|screen_name| {
                 let http_client = &http_client;
                 let _ = self.bearer();
-                let endpoint = if self.endpoint().contains("holaplex.tools") {
-                    self.endpoint().replace("[n]", "")
-                } else {
-                    self.endpoint().to_string()
-                };
+                let endpoint = self.endpoint().replace("[n]", "");
                 async move {
                     http_client
                         .get(format!("{}twitter/{}", endpoint, screen_name))

--- a/crates/graphql/src/schema/dataloaders/wallet.rs
+++ b/crates/graphql/src/schema/dataloaders/wallet.rs
@@ -3,8 +3,6 @@ use objects::profile::{TwitterProfile, TwitterUserProfileResponse};
 
 use super::prelude::*;
 
-const TWITTER_SCREEN_NAME_CHUNKS: usize = 100;
-
 #[async_trait]
 impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
     async fn load(
@@ -12,22 +10,16 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
         screen_names: &[String],
     ) -> TryBatchMap<String, Option<TwitterProfile>> {
         let http_client = reqwest::Client::new();
-        let twitter_bearer_token = self.bearer();
+        let endpoint = self.endpoint();
 
-        let chunked_screen_names = screen_names.chunks(TWITTER_SCREEN_NAME_CHUNKS);
-
-        let twitter_users = chunked_screen_names
-            .clone()
+        let twitter_users = screen_names
             .into_iter()
-            .map(|screen_names| {
+            .map(|screen_name| {
                 let http_client = &http_client;
-
                 async move {
                     http_client
-                        .post("https://api.twitter.com/1.1/users/lookup.json")
+                        .get(format!("{}/twitter/{}", endpoint, screen_name))
                         .header("Accept", "application/json")
-                        .form(&[("screen_name", &screen_names.join(", "))])
-                        .bearer_auth(twitter_bearer_token)
                         .send()
                         .await
                         .map_err(Error::model_convert)?
@@ -42,8 +34,8 @@ impl TryBatchFn<String, Option<TwitterProfile>> for TwitterBatcher {
 
         Ok(twitter_users
             .into_iter()
-            .zip(chunked_screen_names)
-            .filter_map(|(result, _)| result.ok())
+            //.zip(chunked_screen_names)
+            .filter_map(|result| result.ok())
             .flatten()
             .map(|u| (u.screen_name.clone(), u.try_into()))
             .batch(screen_names))

--- a/crates/graphql/src/schema/objects/profile.rs
+++ b/crates/graphql/src/schema/objects/profile.rs
@@ -3,21 +3,21 @@ use tables::twitter_handle_name_services;
 
 use super::prelude::*;
 
-#[derive(Debug, Clone, GraphQLObject)]
-pub struct TwitterProfile {
-    pub handle: String,
-    pub profile_image_url: String,
-    pub profile_image_url_highres: String,
-    pub banner_image_url: String,
+#[derive(Debug, Clone, Deserialize)]
+pub struct TwitterUserProfileResponse {
+    pub screen_name: String,
     pub description: String,
+    pub profile_image_url_https: String,
+    pub profile_banner_url: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct Profile {
+pub struct TwitterProfile {
     pub handle: String,
     pub profile_image_url_lowres: String,
     pub profile_image_url_highres: String,
     pub banner_image_url: String,
+    pub description: String,
 }
 
 impl From<TwitterUserProfileResponse> for TwitterProfile {
@@ -31,7 +31,7 @@ impl From<TwitterUserProfileResponse> for TwitterProfile {
     ) -> Self {
         Self {
             handle: screen_name,
-            profile_image_url: profile_image_url_https.clone(),
+            profile_image_url_lowres: profile_image_url_https.clone(),
             profile_image_url_highres: profile_image_url_https.replace("_normal.", "_bigger."),
             banner_image_url: profile_banner_url,
             description,
@@ -39,48 +39,21 @@ impl From<TwitterUserProfileResponse> for TwitterProfile {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct TwitterProfilePictureResponse {
-    pub data: TwitterProfilePicture,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct TwitterProfilePicture {
-    pub profile_image_url: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct TwitterShowResponse {
-    pub screen_name: String,
-    pub profile_image_url_https: String,
-    pub profile_banner_url: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct TwitterUserProfileResponse {
-    pub screen_name: String,
-    pub description: String,
-    pub profile_image_url_https: String,
-    pub profile_banner_url: String,
-}
-
 #[graphql_object(Context = AppContext)]
-impl Profile {
+impl TwitterProfile {
     fn wallet_address(&self, ctx: &AppContext) -> FieldResult<Option<String>> {
         let db_conn = ctx.shared.db.get()?;
-        let result: Vec<models::TwitterHandle> = twitter_handle_name_services::table
+
+        let handle = twitter_handle_name_services::table
             .select(twitter_handle_name_services::all_columns)
-            .limit(1)
             .filter(twitter_handle_name_services::twitter_handle.eq(&self.handle))
-            .load(&db_conn)
+            .first::<models::TwitterHandle>(&db_conn)
+            .optional()
             .context("Failed to load wallet address")?;
-        if result.is_empty() {
-            return Ok(None);
-        }
-        let matching_item = result.get(0).unwrap();
-        let wallet_address = &matching_item.wallet_address;
-        Ok(Some(wallet_address.to_string()))
+
+        Ok(handle.map(|h| h.wallet_address.into_owned()))
     }
+
     fn handle(&self) -> &str {
         &self.handle
     }
@@ -96,20 +69,8 @@ impl Profile {
     fn banner_image_url(&self) -> &str {
         &self.banner_image_url
     }
-}
 
-impl From<(TwitterProfilePictureResponse, TwitterShowResponse)> for Profile {
-    fn from(
-        (profile_picture_response, show_response): (
-            TwitterProfilePictureResponse,
-            TwitterShowResponse,
-        ),
-    ) -> Self {
-        Self {
-            banner_image_url: show_response.profile_banner_url,
-            handle: show_response.screen_name,
-            profile_image_url_highres: profile_picture_response.data.profile_image_url,
-            profile_image_url_lowres: show_response.profile_image_url_https,
-        }
+    fn description(&self) -> &str {
+        &self.description
     }
 }

--- a/crates/graphql/src/schema/objects/profile.rs
+++ b/crates/graphql/src/schema/objects/profile.rs
@@ -58,6 +58,11 @@ impl TwitterProfile {
         &self.handle
     }
 
+    #[graphql(deprecated = "Use profileImageUrlLowres instead.")]
+    fn profile_image_url(&self) -> &str {
+        &self.profile_image_url_lowres
+    }
+
     fn profile_image_url_lowres(&self) -> &str {
         &self.profile_image_url_lowres
     }

--- a/crates/graphql/src/schema/objects/profile.rs
+++ b/crates/graphql/src/schema/objects/profile.rs
@@ -32,7 +32,7 @@ impl From<TwitterUserProfileResponse> for TwitterProfile {
         Self {
             handle: screen_name,
             profile_image_url_lowres: profile_image_url_https.clone(),
-            profile_image_url_highres: profile_image_url_https.replace("_normal.", "_bigger."),
+            profile_image_url_highres: profile_image_url_https.replace("_normal.", "."),
             banner_image_url: profile_banner_url,
             description,
         }

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -164,14 +164,14 @@ impl QueryRoot {
         ctx: &AppContext,
         #[graphql(description = "Twitter handle")] handle: String,
     ) -> Option<Profile> {
-        let twitter_bearer_token = &ctx.shared.twitter_bearer_token;
+        let asset_cdn = &ctx.shared.asset_proxy.asset_proxy_endpoint;
         let http_client = reqwest::Client::new();
 
         let twitter_show_response: TwitterShowResponse = http_client
-            .get("https://api.twitter.com/1.1/users/show.json")
+            .get(format!("{}/twitter/{}", asset_cdn, &handle))
             .header("Accept", "application/json")
-            .query(&[("screen_name", &handle)])
-            .bearer_auth(twitter_bearer_token)
+            //.query(&[("screen_name", &handle)])
+            //.bearer_auth(twitter_bearer_token)
             .send()
             .await
             .ok()?
@@ -180,13 +180,10 @@ impl QueryRoot {
             .ok()?;
 
         let twitter_profile_picture_response: TwitterProfilePictureResponse = http_client
-            .get(format!(
-                "https://api.twitter.com/2/users/by/username/{}",
-                handle
-            ))
+            .get(format!("{}/twitter/{}", asset_cdn, &handle))
             .header("Accept", "application/json")
-            .query(&[("user.fields", "profile_image_url")])
-            .bearer_auth(twitter_bearer_token)
+            //.query(&[("user.fields", "profile_image_url")])
+            //.bearer_auth(twitter_bearer_token)
             .send()
             .await
             .ok()?

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -164,11 +164,16 @@ impl QueryRoot {
         ctx: &AppContext,
         #[graphql(description = "Twitter handle")] handle: String,
     ) -> Option<Profile> {
-        let asset_cdn = &ctx.shared.asset_proxy.asset_proxy_endpoint;
+        let endpoint = &ctx.shared.asset_proxy.asset_proxy_endpoint;
+        let endpoint = if endpoint.contains("holaplex.tools") {
+            endpoint.replace("[n]", "")
+        } else {
+            endpoint.to_string()
+        };
         let http_client = reqwest::Client::new();
 
         let twitter_show_response: TwitterShowResponse = http_client
-            .get(format!("{}/twitter/{}", asset_cdn, &handle))
+            .get(format!("{}/twitter/{}", endpoint, &handle))
             .header("Accept", "application/json")
             //.query(&[("screen_name", &handle)])
             //.bearer_auth(twitter_bearer_token)
@@ -180,7 +185,7 @@ impl QueryRoot {
             .ok()?;
 
         let twitter_profile_picture_response: TwitterProfilePictureResponse = http_client
-            .get(format!("{}/twitter/{}", asset_cdn, &handle))
+            .get(format!("{}/twitter/{}", endpoint, &handle))
             .header("Accept", "application/json")
             //.query(&[("user.fields", "profile_image_url")])
             //.bearer_auth(twitter_bearer_token)

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -165,11 +165,7 @@ impl QueryRoot {
         #[graphql(description = "Twitter handle")] handle: String,
     ) -> Option<Profile> {
         let endpoint = &ctx.shared.asset_proxy.asset_proxy_endpoint;
-        let endpoint = if endpoint.contains("holaplex.tools") {
-            endpoint.replace("[n]", "")
-        } else {
-            endpoint.to_string()
-        };
+        let endpoint = endpoint.replace("[n]", "");
         let http_client = reqwest::Client::new();
 
         let twitter_show_response: TwitterShowResponse = http_client

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -175,8 +175,6 @@ impl QueryRoot {
         let twitter_show_response: TwitterShowResponse = http_client
             .get(format!("{}/twitter/{}", endpoint, &handle))
             .header("Accept", "application/json")
-            //.query(&[("screen_name", &handle)])
-            //.bearer_auth(twitter_bearer_token)
             .send()
             .await
             .ok()?

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -11,7 +11,7 @@ use objects::{
     listing::{Listing, ListingColumns, ListingRow},
     marketplace::Marketplace,
     nft::{MetadataJson, Nft, NftActivity, NftCount, NftCreator},
-    profile::{Profile, TwitterProfilePictureResponse, TwitterShowResponse},
+    profile::TwitterProfile,
     storefront::{Storefront, StorefrontColumns},
     wallet::Wallet,
 };
@@ -163,37 +163,11 @@ impl QueryRoot {
         &self,
         ctx: &AppContext,
         #[graphql(description = "Twitter handle")] handle: String,
-    ) -> Option<Profile> {
-        let endpoint = &ctx.shared.asset_proxy.asset_proxy_endpoint;
-        let endpoint = endpoint.replace("[n]", "");
-        let http_client = reqwest::Client::new();
-
-        let twitter_show_response: TwitterShowResponse = http_client
-            .get(format!("{}/twitter/{}", endpoint, &handle))
-            .header("Accept", "application/json")
-            .send()
+    ) -> FieldResult<Option<TwitterProfile>> {
+        ctx.twitter_profile_loader
+            .load(handle)
             .await
-            .ok()?
-            .json()
-            .await
-            .ok()?;
-
-        let twitter_profile_picture_response: TwitterProfilePictureResponse = http_client
-            .get(format!("{}/twitter/{}", endpoint, &handle))
-            .header("Accept", "application/json")
-            //.query(&[("user.fields", "profile_image_url")])
-            //.bearer_auth(twitter_bearer_token)
-            .send()
-            .await
-            .ok()?
-            .json()
-            .await
-            .ok()?;
-
-        Some(Profile::from((
-            twitter_profile_picture_response,
-            twitter_show_response,
-        )))
+            .map_err(Into::into)
     }
 
     fn enriched_bonding_changes(


### PR DESCRIPTION
Moving twitter requests to assets cdn to allow caching some calls.
This should help us relief the rate limiting we are currently hitting