### PR TITLE
#499: change featured_listings to choose NFTs whose creators have many followers

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -655,8 +655,9 @@ pub struct BidReceipt<'a> {
 }
 
 /// A row in the `listing_receipts` table
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, QueryableByName)]
 #[diesel(treat_none_as_null = true)]
+#[table_name = "listing_receipts"]
 pub struct ListingReceipt<'a> {
     /// ListingReceipt account pubkey
     pub address: Cow<'a, str>,

--- a/crates/core/src/db/queries/featured_listings.rs
+++ b/crates/core/src/db/queries/featured_listings.rs
@@ -14,25 +14,25 @@ use crate::{
 };
 
 const FEATURED_LISTINGS_QUERY: &str = r"
-SELECT 
-    a.address, 
-    a.trade_state, 
-    a.bookkeeper, 
-    a.auction_house, 
-    a.seller, 
-    a.metadata, 
-    a.purchase_receipt, 
-    a.price, 
-    a.token_size, 
-    a.bump, 
+SELECT
+    a.address,
+    a.trade_state,
+    a.bookkeeper,
+    a.auction_house,
+    a.seller,
+    a.metadata,
+    a.purchase_receipt,
+    a.price,
+    a.token_size,
+    a.bump,
     a.trade_state_bump,
-    a.created_at, 
+    a.created_at,
     a.canceled_at
-    
+
 FROM (
 
-    SELECT 
-        listing_receipts.*, 
+    SELECT
+        listing_receipts.*,
         row_number() OVER (
             PARTITION BY listing_receipts.seller ORDER BY listing_receipts.price DESC
         ) as row

--- a/crates/core/src/db/queries/featured_listings.rs
+++ b/crates/core/src/db/queries/featured_listings.rs
@@ -1,0 +1,66 @@
+//! Query utilities for featured listings.
+
+use anyhow::Context;
+use diesel::{
+    pg::Pg,
+    sql_types::{Array, Integer, Nullable, Text},
+    types::ToSql,
+    RunQueryDsl,
+};
+
+use crate::{
+    db::{models::ListingReceipt, Connection},
+    error::Result,
+};
+
+const FEATURED_LISTINGS_QUERY: &str = r"
+SELECT a.address, a.trade_state, a.bookkeeper, a.auction_house, a.seller, a.metadata, a.purchase_receipt, a.price, a.token_size, a.bump, a.trade_state_bump, a.created_at, a.canceled_at from (
+    SELECT listing_receipts.*, row_number() OVER (PARTITION BY listing_receipts.seller ORDER BY listing_receipts.price DESC) as row
+    FROM listing_receipts, metadata_creators, wallet_totals
+
+    WHERE
+        metadata_creators.creator_address = wallet_totals.address
+        AND listing_receipts.metadata = metadata_creators.metadata_address
+        AND metadata_creators.share > 0
+        AND metadata_creators.verified = true
+        AND listing_receipts.purchase_receipt IS NULL
+        AND listing_receipts.canceled_at IS NULL
+        AND listing_receipts.auction_house = ANY($1)
+        AND (($2 IS NULL) OR NOT(listing_receipts.seller = ANY($2)))
+
+    GROUP BY listing_receipts.metadata, listing_receipts.address
+    ORDER BY sum(wallet_totals.followers) DESC, listing_receipts.price DESC
+
+) as a
+
+WHERE a.row <= $3
+
+LIMIT $4
+OFFSET $5;
+-- $1: auction_houses::text[]
+-- $2: seller_exclusions::text[]
+-- $3: limit_per_seller::integer
+-- $4: limit::integer
+-- $5: offset::integer";
+
+/// Load featured listings
+///
+/// # Errors
+/// This function fails if the underlying SQL query returns an error
+pub fn list(
+    conn: &Connection,
+    auction_houses: impl ToSql<Array<Text>, Pg>,
+    seller_exclusions: impl ToSql<Nullable<Array<Text>>, Pg>,
+    limit_per_seller: impl ToSql<Integer, Pg>,
+    limit: impl ToSql<Integer, Pg>,
+    offset: impl ToSql<Integer, Pg>,
+) -> Result<Vec<ListingReceipt>> {
+    diesel::sql_query(FEATURED_LISTINGS_QUERY)
+        .bind(auction_houses)
+        .bind(seller_exclusions)
+        .bind(limit_per_seller)
+        .bind(limit)
+        .bind(offset)
+        .load(conn)
+        .context("Failed to load featured listings")
+}

--- a/crates/core/src/db/queries/featured_listings.rs
+++ b/crates/core/src/db/queries/featured_listings.rs
@@ -14,8 +14,29 @@ use crate::{
 };
 
 const FEATURED_LISTINGS_QUERY: &str = r"
-SELECT a.address, a.trade_state, a.bookkeeper, a.auction_house, a.seller, a.metadata, a.purchase_receipt, a.price, a.token_size, a.bump, a.trade_state_bump, a.created_at, a.canceled_at from (
-    SELECT listing_receipts.*, row_number() OVER (PARTITION BY listing_receipts.seller ORDER BY listing_receipts.price DESC) as row
+SELECT 
+    a.address, 
+    a.trade_state, 
+    a.bookkeeper, 
+    a.auction_house, 
+    a.seller, 
+    a.metadata, 
+    a.purchase_receipt, 
+    a.price, 
+    a.token_size, 
+    a.bump, 
+    a.trade_state_bump,
+    a.created_at, 
+    a.canceled_at
+    
+FROM (
+
+    SELECT 
+        listing_receipts.*, 
+        row_number() OVER (
+            PARTITION BY listing_receipts.seller ORDER BY listing_receipts.price DESC
+        ) as row
+
     FROM listing_receipts, metadata_creators, wallet_totals
 
     WHERE

--- a/crates/core/src/db/queries/mod.rs
+++ b/crates/core/src/db/queries/mod.rs
@@ -3,6 +3,7 @@
 pub mod activities;
 pub mod bonding_changes;
 pub mod charts;
+pub mod featured_listings;
 pub mod feed_event;
 pub mod graph_connection;
 pub mod listing_denylist;

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -339,9 +339,9 @@ impl QueryRoot {
         &self,
         context: &AppContext,
         #[graphql(description = "Return listings only from these auction houses")]
-        auction_houses: Option<Vec<String>>,
+        auction_houses: Option<Vec<PublicKey<AuctionHouse>>>,
         #[graphql(description = "Return listings not from these sellers")]
-        seller_exclusions: Option<Vec<String>>,
+        seller_exclusions: Option<Vec<PublicKey<Wallet>>>,
         #[graphql(description = "Return at most this many listings per seller")]
         limit_per_seller: Option<i32>,
         #[graphql(description = "Limit for query")] limit: i32,
@@ -349,10 +349,22 @@ impl QueryRoot {
     ) -> FieldResult<Vec<ListingReceipt>> {
         let conn = context.shared.db.get().context("Failed to connect to DB")?;
 
-        let auction_houses = auction_houses
-            .unwrap_or_else(|| context.shared.featured_listings_auction_houses.clone());
-        let seller_exclusions = seller_exclusions
-            .unwrap_or_else(|| context.shared.featured_listings_seller_exclusions.clone());
+        let auction_houses = auction_houses.unwrap_or_else(|| {
+            context
+                .shared
+                .featured_listings_auction_houses
+                .iter()
+                .map(|a| PublicKey::from(a.clone()))
+                .collect()
+        });
+        let seller_exclusions = seller_exclusions.unwrap_or_else(|| {
+            context
+                .shared
+                .featured_listings_seller_exclusions
+                .iter()
+                .map(|s| PublicKey::from(s.clone()))
+                .collect()
+        });
         let limit_per_seller = limit_per_seller.unwrap_or(5);
         let offset = offset.unwrap_or(0);
 


### PR DESCRIPTION
This PR changes the `featured_listings` query to select listings whose creators have many followers by sorting results by the sum of followers of NFT creators.

To increase query speed, the PR also adds filters to only consider creators who have > 0 share and are verified.

closes #499 