### PR TITLE
#514: add query for multiple wallets

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -978,7 +978,7 @@ pub struct MarketStats<'a> {
 }
 
 /// A row in the `twitter_handle_name_services` table
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, QueryableByName)]
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(treat_none_as_null = true)]
 #[table_name = "twitter_handle_name_services"]
 pub struct TwitterHandle<'a> {

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -978,7 +978,7 @@ pub struct MarketStats<'a> {
 }
 
 /// A row in the `twitter_handle_name_services` table
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, QueryableByName)]
 #[diesel(treat_none_as_null = true)]
 #[table_name = "twitter_handle_name_services"]
 pub struct TwitterHandle<'a> {

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -4,12 +4,13 @@ use diesel::{
     expression::{AsExpression, NonAggregate},
     pg::Pg,
     query_builder::{QueryFragment, QueryId},
-    sql_types::Text,
+    sql_types::{Array, Text},
+    types::ToSql,
     AppearsOnTable, OptionalExtension,
 };
 
 use crate::{
-    db::{tables::twitter_handle_name_services, Connection},
+    db::{models::TwitterHandle, tables::twitter_handle_name_services, Connection},
     error::Result,
     prelude::*,
 };
@@ -31,4 +32,31 @@ where
         .first(conn)
         .optional()
         .context("Failed to load twitter handle")
+}
+
+const GET_MULTIPLE_HANDLES_QUERY: &str = r"
+SELECT A.*
+FROM twitter_handle_name_services A
+INNER JOIN (
+    SELECT wallet_address, MAX(write_version) as write_version
+    FROM twitter_handle_name_services
+    WHERE wallet_address = ANY($1)
+    GROUP BY wallet_address
+) B on A.wallet_address = B.wallet_address AND A.write_version = B.write_version
+-- $1: addresses::text[]";
+
+/// Return twitter handles linked to the provide wallet addresses
+///
+/// # Errors
+/// This function fails if the underlying query fails to execute.
+pub fn get_multiple(
+    conn: &Connection,
+    addresses: impl ToSql<Array<Text>, Pg>,
+) -> Result<Vec<TwitterHandle>> {
+    // Appears to not be possible to select a row by unique key by the highest value in another row
+    // See https://stackoverflow.com/a/61964064 (and diesel gitter)
+    diesel::sql_query(GET_MULTIPLE_HANDLES_QUERY)
+        .bind(addresses)
+        .load(conn)
+        .context("Failed to load featured listings")
 }

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -42,5 +42,5 @@ pub fn get_multiple(conn: &Connection, addresses: Vec<String>) -> Result<Vec<Twi
         .filter(twitter_handle_name_services::wallet_address.eq(any(addresses)))
         .select(twitter_handle_name_services::all_columns)
         .load(conn)
-        .context("Failed to load twitter handle")
+        .context("Failed to load twitter handles")
 }

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -53,7 +53,7 @@ pub fn get_multiple(
     conn: &Connection,
     addresses: impl ToSql<Array<Text>, Pg>,
 ) -> Result<Vec<TwitterHandle>> {
-    // Appears to not be possible to select a row by unique key by the 
+    // Appears to not be possible to select a row by unique key by the
     // highest value in another row using diesel ORM
     // See https://stackoverflow.com/a/61964064 (and diesel gitter)
     diesel::sql_query(GET_MULTIPLE_HANDLES_QUERY)

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -53,7 +53,8 @@ pub fn get_multiple(
     conn: &Connection,
     addresses: impl ToSql<Array<Text>, Pg>,
 ) -> Result<Vec<TwitterHandle>> {
-    // Appears to not be possible to select a row by unique key by the highest value in another row
+    // Appears to not be possible to select a row by unique key by the 
+    // highest value in another row using diesel ORM
     // See https://stackoverflow.com/a/61964064 (and diesel gitter)
     diesel::sql_query(GET_MULTIPLE_HANDLES_QUERY)
         .bind(addresses)

--- a/crates/core/src/db/queries/twitter_handle_name_service.rs
+++ b/crates/core/src/db/queries/twitter_handle_name_service.rs
@@ -4,8 +4,7 @@ use diesel::{
     expression::{AsExpression, NonAggregate},
     pg::Pg,
     query_builder::{QueryFragment, QueryId},
-    sql_types::{Array, Text},
-    types::ToSql,
+    sql_types::Text,
     AppearsOnTable, OptionalExtension,
 };
 
@@ -38,11 +37,7 @@ where
 ///
 /// # Errors
 /// This function fails if the underlying query fails to execute.
-pub fn get_multiple(
-    conn: &Connection,
-    addresses: Vec<String>,
-) -> Result<Vec<TwitterHandle>> {
-
+pub fn get_multiple(conn: &Connection, addresses: Vec<String>) -> Result<Vec<TwitterHandle>> {
     twitter_handle_name_services::table
         .filter(twitter_handle_name_services::wallet_address.eq(any(addresses)))
         .select(twitter_handle_name_services::all_columns)

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -413,12 +413,21 @@ impl QueryRoot {
         let conn = context.shared.db.get()?;
 
         let twitter_handles =
-            queries::twitter_handle_name_service::get_multiple(&conn, &addresses).unwrap();
+            queries::twitter_handle_name_service::get_multiple(&conn, &addresses)?;
 
-        Ok(twitter_handles
-            .into_iter()
-            .map(|h| Wallet::new(h.wallet_address.into(), Some(h.twitter_handle.into_owned())))
-            .collect())
+        let mut wallets: HashMap<String, Wallet> = HashMap::new();
+        twitter_handles.into_iter().for_each(|twitter_handle| {
+            wallets.insert(twitter_handle.wallet_address.to_string(), Wallet::new(twitter_handle.wallet_address.into(), Some(twitter_handle.twitter_handle.into())));
+        });
+
+        for address in addresses {
+            let address_string = address.to_string();
+            if !wallets.contains_key(&address_string) {
+                wallets.insert(address_string, Wallet::new(address, None));
+            }
+        }
+
+        Ok(wallets.values().cloned().collect())
     }
 
     fn listings(&self, context: &AppContext) -> FieldResult<Vec<Listing>> {

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -443,7 +443,7 @@ impl QueryRoot {
         let conn = context.shared.db.get()?;
 
         let twitter_handles =
-            queries::twitter_handle_name_service::get_multiple(&conn, &addresses)?;
+            queries::twitter_handle_name_service::get_multiple(&conn, addresses.iter().map(|a| a.to_string()).collect())?;
 
         let mut wallets: HashMap<String, Wallet> = HashMap::new();
         for twitter_handle in twitter_handles {

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -442,8 +442,10 @@ impl QueryRoot {
 
         let conn = context.shared.db.get()?;
 
-        let twitter_handles =
-            queries::twitter_handle_name_service::get_multiple(&conn, addresses.iter().map(|a| a.to_string()).collect())?;
+        let twitter_handles = queries::twitter_handle_name_service::get_multiple(
+            &conn,
+            addresses.iter().map(ToString::to_string).collect(),
+        )?;
 
         let mut wallets: HashMap<String, Wallet> = HashMap::new();
         for twitter_handle in twitter_handles {

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -427,9 +427,8 @@ impl QueryRoot {
         }
 
         for address in addresses {
-            let address_string = address.to_string();
             wallets
-                .entry(address_string)
+                .entry(address.to_string())
                 .or_insert_with(|| Wallet::new(address, None));
         }
 

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -416,15 +416,21 @@ impl QueryRoot {
             queries::twitter_handle_name_service::get_multiple(&conn, &addresses)?;
 
         let mut wallets: HashMap<String, Wallet> = HashMap::new();
-        twitter_handles.into_iter().for_each(|twitter_handle| {
-            wallets.insert(twitter_handle.wallet_address.to_string(), Wallet::new(twitter_handle.wallet_address.into(), Some(twitter_handle.twitter_handle.into())));
-        });
+        for twitter_handle in twitter_handles {
+            wallets.insert(
+                twitter_handle.wallet_address.to_string(),
+                Wallet::new(
+                    twitter_handle.wallet_address.into(),
+                    Some(twitter_handle.twitter_handle.into()),
+                ),
+            );
+        }
 
         for address in addresses {
             let address_string = address.to_string();
-            if !wallets.contains_key(&address_string) {
-                wallets.insert(address_string, Wallet::new(address, None));
-            }
+            wallets
+                .entry(address_string)
+                .or_insert_with(|| Wallet::new(address, None));
         }
 
         Ok(wallets.values().cloned().collect())


### PR DESCRIPTION
This PR adds a list version of the `wallet` query.

# Changes
- added method to get multiple twitter handles from a vector of wallet addresses (`twitter_handle_name_services.rs`, `models.rs`). Note that this uses the `sql_query` method from diesel because of the need to select the row with the highest write version.
- used the new query above to get the handles for all provided wallet addresses and then turned these into wallets (`query_root.rs`)

closes #515 