### PR TITLE
holaplex/#348: nfts search term

### DIFF
--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -105,6 +105,8 @@ enum MetadataCollectionKeys {
 /// List query options
 #[derive(Debug)]
 pub struct ListQueryOptions {
+    /// NFT metadata addresses
+    pub addresses: Option<Vec<String>>,
     /// nft owners
     pub owners: Option<Vec<String>>,
     /// auction houses
@@ -149,6 +151,7 @@ pub type NftColumns = (
 pub fn list(
     conn: &Connection,
     ListQueryOptions {
+        addresses,
         owners,
         creators,
         auction_houses,
@@ -234,6 +237,10 @@ pub fn list(
         .offset(offset)
         .order_by((ListingReceipts::Table, ListingReceipts::Price), Order::Asc)
         .take();
+
+    if let Some(addresses) = addresses {
+        query.and_where(Expr::col(Metadatas::Address).is_in(addresses));
+    }
 
     if let Some(owners) = owners {
         query.and_where(Expr::col(CurrentMetadataOwners::OwnerAddress).is_in(owners));

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -106,7 +106,7 @@ enum MetadataCollectionKeys {
 /// List query options
 #[derive(Debug)]
 pub struct ListQueryOptions {
-    /// NFT metadata addresses
+    /// NFT metadata addresses (combines with other filters)
     pub addresses: Option<Vec<String>>,
     /// nft owners
     pub owners: Option<Vec<String>>,

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -35,6 +35,7 @@ enum Metadatas {
     MintAddress,
     PrimarySaleHappened,
     SellerFeeBasisPoints,
+    UpdateAuthorityAddress,
     Uri,
     Slot,
 }
@@ -193,6 +194,7 @@ pub fn list(
             (Metadatas::Table, Metadatas::Address),
             (Metadatas::Table, Metadatas::Name),
             (Metadatas::Table, Metadatas::SellerFeeBasisPoints),
+            (Metadatas::Table, Metadatas::UpdateAuthorityAddress),
             (Metadatas::Table, Metadatas::MintAddress),
             (Metadatas::Table, Metadatas::PrimarySaleHappened),
             (Metadatas::Table, Metadatas::Uri),

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -4,7 +4,6 @@ use indexer_core::{
         queries::{self, feed_event::EventType},
         tables::twitter_handle_name_services,
     },
-    meilisearch::client::Client,
 };
 use objects::{
     auction_house::AuctionHouse,

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -1,9 +1,7 @@
-use indexer_core::{
-    db::{
-        expression::dsl::all,
-        queries::{self, feed_event::EventType},
-        tables::twitter_handle_name_services,
-    },
+use indexer_core::db::{
+    expression::dsl::all,
+    queries::{self, feed_event::EventType},
+    tables::twitter_handle_name_services,
 };
 use objects::{
     auction_house::AuctionHouse,

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -1,7 +1,10 @@
-use indexer_core::db::{
-    expression::dsl::all,
-    queries::{self, feed_event::EventType},
-    tables::twitter_handle_name_services,
+use indexer_core::{
+    db::{
+        expression::dsl::all,
+        queries::{self, feed_event::EventType},
+        tables::twitter_handle_name_services,
+    },
+    meilisearch::client::Client,
 };
 use objects::{
     auction_house::AuctionHouse,
@@ -285,7 +288,7 @@ impl QueryRoot {
         })
     }
 
-    fn nfts(
+    async fn nfts(
         &self,
         context: &AppContext,
         #[graphql(description = "Filter on owner address")] owners: Option<Vec<PublicKey<Wallet>>>,
@@ -300,6 +303,10 @@ impl QueryRoot {
         #[graphql(description = "Filter nfts associated to the list of auction houses")]
         auction_houses: Option<Vec<PublicKey<AuctionHouse>>>,
         #[graphql(description = "Filter on a collection")] collection: Option<PublicKey<Nft>>,
+        #[graphql(
+            description = "Return NFTs whose metadata contain this search term (case-insensitive)"
+        )]
+        term: Option<String>,
         #[graphql(description = "Limit for query")] limit: i32,
         #[graphql(description = "Offset for query")] offset: i32,
     ) -> FieldResult<Vec<Nft>> {
@@ -308,16 +315,42 @@ impl QueryRoot {
             && creators.is_none()
             && auction_houses.is_none()
             && offerers.is_none()
+            && term.is_none()
         {
             return Err(FieldError::new(
                 "No filter provided! Please provide at least one of the filters",
-                graphql_value!({ "Filters": "owners: Vec<PublicKey>, creators: Vec<PublicKey>, offerers: Vec<PublicKey>, auction_houses: Vec<PublicKey>" }),
+                graphql_value!({ "Filters": "owners: Vec<PublicKey>, creators: Vec<PublicKey>, offerers: Vec<PublicKey>, auction_houses: Vec<PublicKey>, term: String" }),
             ));
         }
 
         let conn = context.shared.db.get().context("failed to connect to db")?;
 
+        let addresses = match term {
+            Some(term) => {
+                let search = &context.shared.search;
+                let search_result = search
+                    .index("metadatas")
+                    .search()
+                    .with_query(&term)
+                    .with_offset(offset.try_into()?)
+                    .with_limit(limit.try_into()?)
+                    .execute::<Value>()
+                    .await
+                    .context("failed to load search result for metadata json")?
+                    .hits;
+
+                Some(
+                    search_result
+                        .into_iter()
+                        .map(|r| MetadataJson::from(r.result).address)
+                        .collect(),
+                )
+            },
+            None => None,
+        };
+
         let query_options = queries::metadatas::ListQueryOptions {
+            addresses,
             owners: owners.map(|a| a.into_iter().map(Into::into).collect()),
             creators: creators.map(|a| a.into_iter().map(Into::into).collect()),
             offerers: offerers.map(|a| a.into_iter().map(Into::into).collect()),


### PR DESCRIPTION
This PR adds an optional search term to the `nfts` query. It works by getting a list of metadata addresses from meili search matching the search term, and passing those addresses into the SQL query.

# Changes
- added optional metadata `addresses` to the `metadatas::list` query (`metadatas.rs`, `query_root.rs`). This is treated the same way as other filters, i.e. it returns NFTs whose metadata addresses match those, but it may further refine the results when combined with other filters.
- added optional search term `term` to the `nfts` query, which passes metadata addresses returned by meili to `metadatas::list` (`query_root.rs`)
- also contains the `update_authority_address` bugfix (`metadatas.rs`)