### PR TITLE
Speed Up Feed Event Query

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use chrono::NaiveDateTime;
-use diesel::sql_types::{Array, Bool, Int4, Int8, Nullable, Text, Timestamp, VarChar};
+use diesel::sql_types::{Array, Bool, Int4, Int8, Nullable, Text, Timestamp, Timestamptz, VarChar};
 use uuid::Uuid;
 
 #[allow(clippy::wildcard_imports)]
@@ -1815,6 +1815,45 @@ pub struct StoreCreatorCount<'a> {
     #[sql_type = "Int8"]
     pub nfts: i64,
 }
+
+/// A join of all `feed_events` related tables into a complete feed event record
+#[derive(Debug, Clone, QueryableByName)]
+pub struct CompleteFeedEvent {
+    /// generated id
+    #[sql_type = "Text"]
+    pub id: String,
+    /// generated created_at
+    #[sql_type = "Timestamptz"]
+    pub created_at: NaiveDateTime,
+    /// wallet associated to the event
+    #[sql_type = "Text"]
+    pub wallet_address: String,
+    /// potentially twitter handle for associated wallet
+    #[sql_type = "Nullable<Text>"]
+    pub twitter_handle: Option<String>,
+    /// metadata address that triggered the mint event
+    #[sql_type = "Nullable<Text>"]
+    pub metadata_address: Option<String>,
+    /// purchase receipt address that triggered the purchase event
+    #[sql_type = "Nullable<Text>"]
+    pub purchase_receipt_address: Option<String>,
+    #[sql_type = "Nullable<Text>"]
+    /// bid receipt address that triggered the offer event
+    pub bid_receipt_address: Option<String>,
+    /// the lifecycle of the offer event
+    #[sql_type = "Nullable<Text>"]
+    pub offer_lifecycle: Option<String>,
+    /// listing receipt address that triggered the listing event
+    #[sql_type = "Nullable<Text>"]
+    pub listing_receipt_address: Option<String>,
+    /// the lifecycle of the listing event
+    #[sql_type = "Nullable<Text>"]
+    pub listing_lifecycle: Option<String>,
+    /// graph connection address that triggered the follow event
+    #[sql_type = "Nullable<Text>"]
+    pub graph_connection_address: Option<String>,
+}
+
 /// A row in the `feed_events` table
 #[derive(Debug, Clone, Copy, Queryable, Insertable)]
 #[table_name = "feed_events"]

--- a/crates/graphql/src/schema/objects/feed_event.rs
+++ b/crates/graphql/src/schema/objects/feed_event.rs
@@ -1,8 +1,8 @@
-use indexer_core::db::{models, queries};
+use indexer_core::db::models;
 use juniper::GraphQLUnion;
 use objects::{
     bid_receipt::BidReceipt, graph_connection::GraphConnection, listing_receipt::ListingReceipt,
-    nft::Nft, profile::TwitterProfile, purchase_receipt::PurchaseReceipt,
+    nft::Nft, profile::TwitterProfile, purchase_receipt::PurchaseReceipt, wallet::Wallet,
 };
 
 use super::prelude::*;
@@ -13,7 +13,7 @@ pub struct MintEvent {
     created_at: DateTime<Utc>,
     feed_event_id: String,
     twitter_handle: Option<String>,
-    wallet_address: String,
+    wallet_address: PublicKey<Wallet>,
     metadata_address: PublicKey<Nft>,
 }
 
@@ -22,7 +22,7 @@ pub struct FollowEvent {
     created_at: DateTime<Utc>,
     feed_event_id: String,
     twitter_handle: Option<String>,
-    wallet_address: String,
+    wallet_address: PublicKey<Wallet>,
     graph_connection_address: PublicKey<GraphConnection>,
 }
 
@@ -32,7 +32,7 @@ impl FollowEvent {
         self.created_at
     }
 
-    fn wallet_address(&self) -> &str {
+    fn wallet_address(&self) -> &PublicKey<Wallet> {
         &self.wallet_address
     }
 
@@ -69,7 +69,7 @@ pub struct PurchaseEvent {
     created_at: DateTime<Utc>,
     feed_event_id: String,
     twitter_handle: Option<String>,
-    wallet_address: String,
+    wallet_address: PublicKey<Wallet>,
     purchase_receipt_address: PublicKey<PurchaseReceipt>,
 }
 
@@ -79,7 +79,7 @@ impl PurchaseEvent {
         self.created_at
     }
 
-    fn wallet_address(&self) -> &str {
+    fn wallet_address(&self) -> &PublicKey<Wallet> {
         &self.wallet_address
     }
 
@@ -116,7 +116,7 @@ pub struct OfferEvent {
     created_at: DateTime<Utc>,
     feed_event_id: String,
     twitter_handle: Option<String>,
-    wallet_address: String,
+    wallet_address: PublicKey<Wallet>,
     bid_receipt_address: PublicKey<BidReceipt>,
     lifecycle: String,
 }
@@ -127,7 +127,7 @@ impl OfferEvent {
         self.created_at
     }
 
-    fn wallet_address(&self) -> &str {
+    fn wallet_address(&self) -> &PublicKey<Wallet> {
         &self.wallet_address
     }
 
@@ -169,7 +169,7 @@ pub struct ListingEvent {
     feed_event_id: String,
     listing_receipt_address: PublicKey<ListingReceipt>,
     twitter_handle: Option<String>,
-    wallet_address: String,
+    wallet_address: PublicKey<Wallet>,
     lifecycle: String,
 }
 
@@ -179,7 +179,7 @@ impl ListingEvent {
         self.created_at
     }
 
-    fn wallet_address(&self) -> &str {
+    fn wallet_address(&self) -> &PublicKey<Wallet> {
         &self.wallet_address
     }
 
@@ -221,7 +221,7 @@ impl MintEvent {
         self.created_at
     }
 
-    fn wallet_address(&self) -> &str {
+    fn wallet_address(&self) -> &PublicKey<Wallet> {
         &self.wallet_address
     }
 
@@ -269,111 +269,78 @@ pub enum FeedEvent {
 #[error("Invalid feed event variant")]
 pub struct TryFromError;
 
-impl<'a> TryFrom<queries::feed_event::Columns<'a>> for FeedEvent {
+impl TryFrom<models::CompleteFeedEvent> for FeedEvent {
     type Error = TryFromError;
 
     fn try_from(
-        (
-            models::FeedEvent { id, created_at },
+        models::CompleteFeedEvent {
+            id,
+            created_at,
             wallet_address,
             twitter_handle,
-            mint_event,
-            offer_event,
-            listing_event,
-            purchase_event,
-            follow_event,
-        ): queries::feed_event::Columns,
+            metadata_address,
+            purchase_receipt_address,
+            bid_receipt_address,
+            offer_lifecycle,
+            listing_receipt_address,
+            listing_lifecycle,
+            graph_connection_address,
+        }: models::CompleteFeedEvent,
     ) -> Result<Self, Self::Error> {
         match (
-            mint_event,
-            offer_event,
-            listing_event,
-            purchase_event,
-            follow_event,
+            metadata_address,
+            (bid_receipt_address, offer_lifecycle),
+            (listing_receipt_address, listing_lifecycle),
+            purchase_receipt_address,
+            graph_connection_address,
         ) {
-            (
-                Some(models::MintEvent {
-                    metadata_address, ..
-                }),
-                None,
-                None,
-                None,
-                None,
-            ) => Ok(Self::Mint(MintEvent {
-                feed_event_id: id.to_string(),
-                created_at: DateTime::from_utc(created_at, Utc),
-                metadata_address: metadata_address.into_owned().into(),
-                twitter_handle,
-                wallet_address,
-            })),
-            (
-                None,
-                Some(models::OfferEvent {
-                    bid_receipt_address,
+            (Some(metadata_address), (None, None), (None, None), None, None) => {
+                Ok(Self::Mint(MintEvent {
+                    feed_event_id: id,
+                    created_at: DateTime::from_utc(created_at, Utc),
+                    metadata_address: metadata_address.into(),
+                    twitter_handle,
+                    wallet_address: wallet_address.into(),
+                }))
+            },
+            (None, (Some(bid_receipt_address), Some(lifecycle)), (None, None), None, None) => {
+                Ok(Self::Offer(OfferEvent {
+                    feed_event_id: id,
+                    created_at: DateTime::from_utc(created_at, Utc),
+                    bid_receipt_address: bid_receipt_address.into(),
                     lifecycle,
-                    ..
-                }),
-                None,
-                None,
-                None,
-            ) => Ok(Self::Offer(OfferEvent {
-                feed_event_id: id.to_string(),
-                created_at: DateTime::from_utc(created_at, Utc),
-                bid_receipt_address: bid_receipt_address.into_owned().into(),
-                lifecycle: lifecycle.to_string(),
-                twitter_handle,
-                wallet_address,
-            })),
-            (
-                None,
-                None,
-                Some(models::ListingEvent {
-                    listing_receipt_address,
+                    twitter_handle,
+                    wallet_address: wallet_address.into(),
+                }))
+            },
+            (None, (None, None), (Some(listing_receipt_address), Some(lifecycle)), None, None) => {
+                Ok(Self::Listing(ListingEvent {
+                    feed_event_id: id,
+                    created_at: DateTime::from_utc(created_at, Utc),
+                    listing_receipt_address: listing_receipt_address.into(),
                     lifecycle,
-                    ..
-                }),
-                None,
-                None,
-            ) => Ok(Self::Listing(ListingEvent {
-                feed_event_id: id.to_string(),
-                created_at: DateTime::from_utc(created_at, Utc),
-                listing_receipt_address: listing_receipt_address.into_owned().into(),
-                lifecycle: lifecycle.to_string(),
-                twitter_handle,
-                wallet_address,
-            })),
-            (
-                None,
-                None,
-                None,
-                Some(models::PurchaseEvent {
-                    purchase_receipt_address,
-                    ..
-                }),
-                None,
-            ) => Ok(Self::Purchase(PurchaseEvent {
-                feed_event_id: id.to_string(),
-                created_at: DateTime::from_utc(created_at, Utc),
-                purchase_receipt_address: purchase_receipt_address.into_owned().into(),
-                twitter_handle,
-                wallet_address,
-            })),
-            (
-                None,
-                None,
-                None,
-                None,
-                Some(models::FollowEvent {
-                    graph_connection_address,
-                    ..
-                }),
-            ) => Ok(Self::Follow(FollowEvent {
-                feed_event_id: id.to_string(),
-                created_at: DateTime::from_utc(created_at, Utc),
-                graph_connection_address: graph_connection_address.into_owned().into(),
-                twitter_handle,
-                wallet_address,
-            })),
+                    twitter_handle,
+                    wallet_address: wallet_address.into(),
+                }))
+            },
+            (None, (None, None), (None, None), Some(purchase_receipt_address), None) => {
+                Ok(Self::Purchase(PurchaseEvent {
+                    feed_event_id: id,
+                    created_at: DateTime::from_utc(created_at, Utc),
+                    purchase_receipt_address: purchase_receipt_address.into(),
+                    twitter_handle,
+                    wallet_address: wallet_address.into(),
+                }))
+            },
+            (None, (None, None), (None, None), None, Some(graph_connection_address)) => {
+                Ok(Self::Follow(FollowEvent {
+                    feed_event_id: id,
+                    created_at: DateTime::from_utc(created_at, Utc),
+                    graph_connection_address: graph_connection_address.into(),
+                    twitter_handle,
+                    wallet_address: wallet_address.into(),
+                }))
+            },
             _ => {
                 debug!("feed_event_id: {}", id);
 

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -121,7 +121,7 @@ impl QueryRoot {
 
         let feed_events = queries::feed_event::list(
             &conn,
-            wallet,
+            wallet.to_string(),
             limit.try_into()?,
             offset.try_into()?,
             exclude_types_parsed,


### PR DESCRIPTION
### Changes
- Migrate feed event query to sea-query
- Use inner join of graph_connections on feed_wallet_events to filter for events where the wallet is followed by the current user.
- Perform limit on the results of querying the feed events by filters

### Query
```sql
WITH "events" AS
	(SELECT "feed_events"."id",
			"feed_events"."created_at",
			"feed_event_wallets"."wallet_address",
			"twitter_handle_name_services"."twitter_handle",
			"mint_events"."metadata_address",
			"purchase_events"."purchase_receipt_address",
			"offer_events"."bid_receipt_address",
			"offer_events"."lifecycle",
			"listing_events"."listing_receipt_address",
			"listing_events"."lifecycle",
			"follow_events"."graph_connection_address"
		FROM "feed_events"
		INNER JOIN "feed_event_wallets" ON "feed_event_wallets"."feed_event_id" = "feed_events"."id"
		INNER JOIN "graph_connections" ON "graph_connections"."to_account" = "feed_event_wallets"."wallet_address"
		LEFT JOIN "twitter_handle_name_services" ON "twitter_handle_name_services"."wallet_address" = "feed_event_wallets"."wallet_address"
		LEFT JOIN "follow_events" ON "follow_events"."feed_event_id" = "feed_events"."id"
		LEFT JOIN "mint_events" ON "mint_events"."feed_event_id" = "feed_events"."id"
		LEFT JOIN "purchase_events" ON "purchase_events"."feed_event_id" = "feed_events"."id"
		LEFT JOIN "offer_events" ON "offer_events"."feed_event_id" = "feed_events"."id"
		LEFT JOIN "listing_events" ON "listing_events"."feed_event_id" = "feed_events"."id"
		WHERE "graph_connections"."from_account" = 'ALphA7iWKMUi8owfbSKFm2i3BxG6LbasYYXt8sP85Upz'
			AND "follow_events"."graph_connection_address" IS NULL
		ORDER BY "created_at" DESC)
SELECT *
FROM "events"
ORDER BY "created_at" DESC
LIMIT 10
OFFSET 0
```
<img width="1313" alt="Screen Shot 2022-06-13 at 1 02 18 PM" src="https://user-images.githubusercontent.com/2388118/173340105-4390adda-87da-4911-baaf-79f19d946172.png">

