### PR TITLE
[HotFix] Remove duplicate feed events

### DIFF
--- a/crates/core/src/db/queries/feed_event.rs
+++ b/crates/core/src/db/queries/feed_event.rs
@@ -109,6 +109,7 @@ pub fn list(
     exclude_types: Option<Vec<EventType>>,
 ) -> Result<Vec<CompleteFeedEvent>> {
     let mut events_query = Query::select()
+        .distinct()
         .columns(vec![
             (FeedEvents::Table, FeedEvents::Id),
             (FeedEvents::Table, FeedEvents::CreatedAt),


### PR DESCRIPTION
### Changes
- Select distinct for feed event query to remove identical entries before the limit/offset are applied.