### PR TITLE
holaplex/#541: add stats for profiles

### DIFF
--- a/crates/graphql/src/schema/objects/profile.rs
+++ b/crates/graphql/src/schema/objects/profile.rs
@@ -52,3 +52,21 @@ impl TwitterProfile {
         &self.description
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct ProfilesStats {}
+
+#[graphql_object(Context = AppContext)]
+impl ProfilesStats {
+    #[graphql(description = "The total number of indexed profiles")]
+    fn total_profiles(&self, context: &AppContext) -> FieldResult<i32> {
+        let conn = context.shared.db.get()?;
+
+        let count: i64 = twitter_handle_name_services::table
+            .count()
+            .get_result(&conn)
+            .context("failed to load total profiles count")?;
+
+        Ok(count.try_into()?)
+    }
+}

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -16,7 +16,7 @@ use objects::{
     listing_receipt::ListingReceipt,
     marketplace::Marketplace,
     nft::{MetadataJson, Nft, NftActivity, NftCount, NftCreator},
-    profile::TwitterProfile,
+    profile::{ProfilesStats, TwitterProfile},
     storefront::{Storefront, StorefrontColumns},
     wallet::Wallet,
 };
@@ -27,7 +27,7 @@ use tables::{
     metadata_jsons, metadatas, store_config_jsons, storefronts, wallet_totals,
 };
 
-use super::{objects::profile::ProfilesStats, prelude::*};
+use super::prelude::*;
 pub struct QueryRoot;
 
 #[derive(GraphQLInputObject, Clone, Debug)]

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -27,7 +27,7 @@ use tables::{
     metadata_jsons, metadatas, store_config_jsons, storefronts, wallet_totals,
 };
 
-use super::prelude::*;
+use super::{objects::profile::ProfilesStats, prelude::*};
 pub struct QueryRoot;
 
 #[derive(GraphQLInputObject, Clone, Debug)]
@@ -583,6 +583,11 @@ impl QueryRoot {
             .into_iter()
             .map(|r| r.result.into())
             .collect::<Vec<Wallet>>())
+    }
+
+    #[graphql(description = "returns stats about profiles")]
+    async fn profiles_stats(&self) -> FieldResult<ProfilesStats> {
+        Ok(ProfilesStats {})
     }
 
     #[graphql(


### PR DESCRIPTION
This PR adds an endpoint to serve stats across profiles. Right now that's just the total number of profiles, but will be updated in the future with a breakdown of different types of profiles (e.g. creators, collectors, etc).