### PR TITLE
Filter out nft listings that are associated to a purchase

### DIFF
--- a/crates/core/migrations/2022-07-05-173659_add_listings_indexes/down.sql
+++ b/crates/core/migrations/2022-07-05-173659_add_listings_indexes/down.sql
@@ -1,0 +1,7 @@
+drop index if exists listings_canceled_at_purchase_id_null_idx;
+
+drop index if exists listings_auction_house_idx;
+
+drop index if exists listings_metadata_idx;
+
+drop index if exists listings_seller_idx;

--- a/crates/core/migrations/2022-07-05-173659_add_listings_indexes/up.sql
+++ b/crates/core/migrations/2022-07-05-173659_add_listings_indexes/up.sql
@@ -1,0 +1,11 @@
+create index if not exists listings_canceled_at_purchase_id_null_idx on
+  listings (canceled_at, purchase_id) WHERE canceled_at IS NULL AND purchase_id IS NULL;
+
+create index if not exists listings_auction_house_idx on
+  listings using hash (auction_house);
+
+create index if not exists listings_metadata_idx on
+  listings using hash (metadata);
+
+create index if not exists listings_seller_idx on
+  listings using hash (seller);

--- a/crates/core/migrations/2022-07-05-210410_add_offers_indexes/down.sql
+++ b/crates/core/migrations/2022-07-05-210410_add_offers_indexes/down.sql
@@ -1,0 +1,7 @@
+drop index if exists offers_canceled_at_purchase_id_null_idx;
+
+drop index if exists offers_auction_house_idx;
+
+drop index if exists offers_metadata_idx;
+
+drop index if exists offers_buyer_idx;

--- a/crates/core/migrations/2022-07-05-210410_add_offers_indexes/up.sql
+++ b/crates/core/migrations/2022-07-05-210410_add_offers_indexes/up.sql
@@ -1,0 +1,11 @@
+create index if not exists offers_canceled_at_purchase_id_null_idx on
+  offers (canceled_at, purchase_id) WHERE canceled_at IS NULL AND purchase_id IS NULL;
+
+create index if not exists offers_auction_house_idx on
+  offers using hash (auction_house);
+
+create index if not exists offers_metadata_idx on
+  offers using hash (metadata);
+
+create index if not exists offers_buyer_idx on
+  offers using hash (buyer);

--- a/crates/core/migrations/2022-07-05-212752_add_purchases_indexes/down.sql
+++ b/crates/core/migrations/2022-07-05-212752_add_purchases_indexes/down.sql
@@ -1,0 +1,9 @@
+drop index if exists purchases_metadata_idx;
+
+drop index if exists purchases_created_at_idx;
+
+drop index if exists purchases_auction_house_idx;
+
+drop index if exists purchases_seller_idx;
+
+drop index if exists purchases_buyer_idx;

--- a/crates/core/migrations/2022-07-05-212752_add_purchases_indexes/up.sql
+++ b/crates/core/migrations/2022-07-05-212752_add_purchases_indexes/up.sql
@@ -1,0 +1,14 @@
+create index if not exists purchases_metadata_idx on
+  purchases using hash (metadata);
+
+create index if not exists purchases_created_at_idx on
+  purchases (created_at);
+
+create index if not exists purchases_auction_house_idx on
+  purchases using hash (auction_house);
+
+create index if not exists purchases_seller_idx on
+  purchases using hash (seller);
+
+create index if not exists purchases_buyer_idx on
+  purchases using hash (buyer);

--- a/crates/graphql/src/schema/dataloaders/ah_listing.rs
+++ b/crates/graphql/src/schema/dataloaders/ah_listing.rs
@@ -39,6 +39,7 @@ impl TryBatchFn<PublicKey<Nft>, Vec<AhListing>> for Batcher {
             )
             .select(listings::all_columns)
             .filter(listings::canceled_at.is_null())
+            .filter(listings::purchase_id.is_null())
             .filter(listings::metadata.eq(any(addresses)))
             .load(&conn)
             .context("Failed to load listings")?;


### PR DESCRIPTION
### Fix
- NFT listings should be filtered out if they are associated to a purchase.

### Changes
- Add helpful indexes to purchases, listings, and offers based on review of queries in use.