### PR TITLE
basic tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "env_logger",
+ "lazy_static",
  "log",
  "md5",
  "meilisearch-sdk",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -67,3 +67,7 @@ base64 = { version = "0.13.0", optional = true }
 cid = { version = "0.7.0", optional = true }
 url = "2.2.2"
 md5 = { version = "0.7.0", optional = true }
+
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -165,3 +165,378 @@ pub fn connect(args: ConnectArgs, mode: ConnectMode) -> Result<(Pool, Connection
 
     Ok((pool, ty))
 }
+
+#[cfg(test)]
+pub mod test {
+    use diesel::{insert_into, prelude::*};
+    use uuid::Uuid;
+
+    use super::{
+        connect, models,
+        schema::{
+            auction_houses, listings, metadata_collection_keys, metadata_jsons, metadatas,
+            purchases,
+        },
+        ConnectArgs,
+    };
+    use crate::prelude::*;
+
+    fn initialize() -> super::Pool {
+        let conn_args = ConnectArgs {
+            database_read_url: None,
+            database_write_url: Some(
+                "postgres://postgres:holap1ex@localhost:5337/holaplex-indexer".into(),
+            ),
+            database_url: None,
+        };
+        let (pool, _) = connect(conn_args, crate::db::ConnectMode::Write)
+            .expect("failed to connect to database");
+        let conn = pool.get().expect("failed to get connection to database");
+
+        let nft_a_metadata_address = Borrowed("metadata_a");
+        let nft_b_metadata_address = Borrowed("metadata_b");
+        let nft_c_metadata_address = Borrowed("metadata_c");
+        let nft_d_metadata_address = Borrowed("metadata_d");
+        let nft_d_purchase_id = Some(
+            Uuid::parse_str("00000000-0000-0000-0000-000000000009").expect("failed to parse UUID"),
+        );
+        let collection_metadata_address = Borrowed("collection_a");
+        let auction_house_address = Borrowed("auction_house_a");
+        let seller_address = Borrowed("seller_a");
+        let buyer_address = Borrowed("buyer_a");
+
+        insert_into(metadata_collection_keys::table)
+            .values(vec![
+                models::MetadataCollectionKey {
+                    metadata_address: nft_a_metadata_address.clone(),
+                    collection_address: collection_metadata_address.clone(),
+                    verified: true,
+                },
+                models::MetadataCollectionKey {
+                    metadata_address: nft_b_metadata_address.clone(),
+                    collection_address: collection_metadata_address.clone(),
+                    verified: true,
+                },
+                models::MetadataCollectionKey {
+                    metadata_address: nft_c_metadata_address.clone(),
+                    collection_address: collection_metadata_address.clone(),
+                    verified: true,
+                },
+                models::MetadataCollectionKey {
+                    metadata_address: nft_d_metadata_address.clone(),
+                    collection_address: collection_metadata_address.clone(),
+                    verified: true,
+                },
+            ])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed metadata_collection_keys");
+
+        insert_into(metadatas::table)
+            .values(vec![
+                models::Metadata {
+                    address: nft_a_metadata_address.clone(),
+                    name: Borrowed("nft A"),
+                    symbol: Borrowed("symbol"),
+                    uri: Borrowed("http://example.com/nft-a-uri"),
+                    seller_fee_basis_points: 100,
+                    update_authority_address: Borrowed("update authority"),
+                    mint_address: collection_metadata_address.clone(),
+                    primary_sale_happened: true,
+                    is_mutable: false,
+                    edition_nonce: None,
+                    edition_pda: Borrowed("nft edition pda"),
+                    token_standard: None,
+                    slot: Some(0),
+                    burned: false,
+                },
+                models::Metadata {
+                    address: nft_b_metadata_address.clone(),
+                    name: Borrowed("nft B"),
+                    symbol: Borrowed("symbol"),
+                    uri: Borrowed("http://example.com/nft-b-uri"),
+                    seller_fee_basis_points: 100,
+                    update_authority_address: Borrowed("update authority"),
+                    mint_address: collection_metadata_address.clone(),
+                    primary_sale_happened: true,
+                    is_mutable: false,
+                    edition_nonce: None,
+                    edition_pda: Borrowed("nft edition pda"),
+                    token_standard: None,
+                    slot: Some(0),
+                    burned: false,
+                },
+                models::Metadata {
+                    address: nft_c_metadata_address.clone(),
+                    name: Borrowed("nft C"),
+                    symbol: Borrowed("symbol"),
+                    uri: Borrowed("http://example.com/nft-c-uri"),
+                    seller_fee_basis_points: 100,
+                    update_authority_address: Borrowed("update authority"),
+                    mint_address: collection_metadata_address.clone(),
+                    primary_sale_happened: true,
+                    is_mutable: false,
+                    edition_nonce: None,
+                    edition_pda: Borrowed("nft edition pda"),
+                    token_standard: None,
+                    slot: Some(0),
+                    burned: false,
+                },
+                models::Metadata {
+                    address: nft_d_metadata_address.clone(),
+                    name: Borrowed("nft D"),
+                    symbol: Borrowed("symbol"),
+                    uri: Borrowed("http://example.com/nft-d-uri"),
+                    seller_fee_basis_points: 100,
+                    update_authority_address: Borrowed("update authority"),
+                    mint_address: collection_metadata_address.clone(),
+                    primary_sale_happened: true,
+                    is_mutable: false,
+                    edition_nonce: None,
+                    edition_pda: Borrowed("nft edition pda"),
+                    token_standard: None,
+                    slot: Some(0),
+                    burned: false,
+                },
+                models::Metadata {
+                    address: collection_metadata_address.clone(),
+                    name: Borrowed("collection name"),
+                    symbol: Borrowed("symbol"),
+                    uri: Borrowed("http://example.com/collection-uri"),
+                    seller_fee_basis_points: 100,
+                    update_authority_address: Borrowed("update authority"),
+                    mint_address: Borrowed("collection mint"),
+                    primary_sale_happened: true,
+                    is_mutable: false,
+                    edition_nonce: None,
+                    edition_pda: Borrowed("collection edition pda"),
+                    token_standard: None,
+                    slot: Some(0),
+                    burned: false,
+                },
+            ])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed metadatas");
+
+        insert_into(auction_houses::table)
+            .values(vec![models::AuctionHouse {
+                address: auction_house_address.clone(),
+                treasury_mint: Borrowed("So11111111111111111111111111111111111111112"),
+                auction_house_treasury: Borrowed("treasury"),
+                treasury_withdrawal_destination: Borrowed("treasury withdrawal"),
+                fee_withdrawal_destination: Borrowed("fee withdrawal"),
+                authority: Borrowed("auction house authority"),
+                creator: Borrowed("auction house creator"),
+                bump: 0,
+                treasury_bump: 0,
+                fee_payer_bump: 0,
+                seller_fee_basis_points: 100,
+                requires_sign_off: false,
+                can_change_sale_price: false,
+                auction_house_fee_account: Borrowed("auction house fee account"),
+            }])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed auction_houses");
+
+        insert_into(listings::table)
+            .values(vec![
+                models::Listing {
+                    id: Some(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000001")
+                            .expect("failed to parse UUID"),
+                    ),
+                    trade_state: Borrowed("nft_a trade state"),
+                    auction_house: auction_house_address.clone(),
+                    seller: seller_address.clone(),
+                    metadata: nft_a_metadata_address.clone(),
+                    purchase_id: None,
+                    price: 1,
+                    token_size: 1,
+                    trade_state_bump: 0,
+                    created_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    canceled_at: None,
+                    slot: 0,
+                    write_version: Some(0),
+                },
+                models::Listing {
+                    id: Some(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000002")
+                            .expect("failed to parse UUID"),
+                    ),
+                    trade_state: Borrowed("nft_b trade state"),
+                    auction_house: auction_house_address.clone(),
+                    seller: seller_address.clone(),
+                    metadata: nft_b_metadata_address.clone(),
+                    purchase_id: None,
+                    price: 1,
+                    token_size: 1,
+                    trade_state_bump: 0,
+                    created_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    canceled_at: None,
+                    slot: 0,
+                    write_version: Some(0),
+                },
+                models::Listing {
+                    id: Some(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000003")
+                            .expect("failed to parse UUID"),
+                    ),
+                    trade_state: Borrowed("nft_c trade state"),
+                    auction_house: auction_house_address.clone(),
+                    seller: seller_address.clone(),
+                    metadata: nft_c_metadata_address.clone(),
+                    purchase_id: None,
+                    price: 1,
+                    token_size: 1,
+                    trade_state_bump: 0,
+                    created_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    canceled_at: None,
+                    slot: 0,
+                    write_version: Some(0),
+                },
+                models::Listing {
+                    id: Some(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000004")
+                            .expect("failed to parse UUID"),
+                    ),
+                    trade_state: Borrowed("nft_d trade state"),
+                    auction_house: auction_house_address.clone(),
+                    seller: seller_address.clone(),
+                    metadata: nft_d_metadata_address.clone(),
+                    purchase_id: nft_d_purchase_id.clone(),
+                    price: 1,
+                    token_size: 1,
+                    trade_state_bump: 0,
+                    created_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    canceled_at: None,
+                    slot: 0,
+                    write_version: Some(0),
+                },
+            ])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed purchases");
+
+        insert_into(purchases::table)
+            .values(vec![models::Purchase {
+                id: nft_d_purchase_id.clone(),
+                buyer: buyer_address.clone(),
+                seller: seller_address.clone(),
+                auction_house: auction_house_address.clone(),
+                metadata: nft_d_metadata_address.clone(),
+                token_size: 1,
+                price: 1,
+                created_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                slot: 0,
+                write_version: None,
+            }])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed purchases");
+
+        insert_into(metadata_jsons::table)
+            .values(vec![
+                models::MetadataJson {
+                    metadata_address: nft_a_metadata_address,
+                    fingerprint: Borrowed(&Vec::<u8>::new()),
+                    updated_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    description: Some(Borrowed("nft A description")),
+                    image: Some(Borrowed("http://example.com/nft-a-image")),
+                    animation_url: Some(Borrowed("http://example.com/nft-a-animation")),
+                    external_url: Some(Borrowed("http://example.com/nft-a-external")),
+                    category: Some(Borrowed("nft A category")),
+                    raw_content: Borrowed(
+                        &serde_json::from_str("{}")
+                            .expect("Failed to deserialize metadata content"),
+                    ),
+                    model: Some(Borrowed("model")),
+                    fetch_uri: Borrowed("http://example.com/nft-a-fetch-uri"),
+                    slot: 0,
+                    write_version: 0,
+                },
+                models::MetadataJson {
+                    metadata_address: nft_b_metadata_address,
+                    fingerprint: Borrowed(&Vec::<u8>::new()),
+                    updated_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    description: Some(Borrowed("nft B description")),
+                    image: Some(Borrowed("http://example.com/nft-b-image")),
+                    animation_url: Some(Borrowed("http://example.com/nft-b-animation")),
+                    external_url: Some(Borrowed("http://example.com/nft-b-external")),
+                    category: Some(Borrowed("nft B category")),
+                    raw_content: Borrowed(
+                        &serde_json::from_str("{}")
+                            .expect("Failed to deserialize metadata content"),
+                    ),
+                    model: Some(Borrowed("model")),
+                    fetch_uri: Borrowed("http://example.com/nft-b-fetch-uri"),
+                    slot: 0,
+                    write_version: 0,
+                },
+                models::MetadataJson {
+                    metadata_address: nft_c_metadata_address,
+                    fingerprint: Borrowed(&Vec::<u8>::new()),
+                    updated_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    description: Some(Borrowed("nft C description")),
+                    image: Some(Borrowed("http://example.com/nft-c-image")),
+                    animation_url: Some(Borrowed("http://example.com/nft-c-animation")),
+                    external_url: Some(Borrowed("http://example.com/nft-c-external")),
+                    category: Some(Borrowed("nft C category")),
+                    raw_content: Borrowed(
+                        &serde_json::from_str("{}")
+                            .expect("Failed to deserialize metadata content"),
+                    ),
+                    model: Some(Borrowed("model")),
+                    fetch_uri: Borrowed("http://example.com/nft-c-fetch-uri"),
+                    slot: 0,
+                    write_version: 0,
+                },
+                models::MetadataJson {
+                    metadata_address: nft_d_metadata_address,
+                    fingerprint: Borrowed(&Vec::<u8>::new()),
+                    updated_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    description: Some(Borrowed("nft C description")),
+                    image: Some(Borrowed("http://example.com/nft-c-image")),
+                    animation_url: Some(Borrowed("http://example.com/nft-c-animation")),
+                    external_url: Some(Borrowed("http://example.com/nft-c-external")),
+                    category: Some(Borrowed("nft B category")),
+                    raw_content: Borrowed(
+                        &serde_json::from_str("{}")
+                            .expect("Failed to deserialize metadata content"),
+                    ),
+                    model: Some(Borrowed("model")),
+                    fetch_uri: Borrowed("http://example.com/nft-c-fetch-uri"),
+                    slot: 0,
+                    write_version: 0,
+                },
+                models::MetadataJson {
+                    metadata_address: collection_metadata_address,
+                    fingerprint: Borrowed(&Vec::<u8>::new()),
+                    updated_at: NaiveDate::from_ymd(2020, 1, 2).and_hms(0, 0, 0),
+                    description: Some(Borrowed("collection description")),
+                    image: Some(Borrowed("http://example.com/collection-image")),
+                    animation_url: Some(Borrowed("http://example.com/collection-animation")),
+                    external_url: Some(Borrowed("http://example.com/collection-external")),
+                    category: Some(Borrowed("collection category")),
+                    raw_content: Borrowed(
+                        &serde_json::from_str("{}")
+                            .expect("Failed to deserialize metadata content"),
+                    ),
+                    model: Some(Borrowed("model")),
+                    fetch_uri: Borrowed("http://example.com/collection-fetch-uri"),
+                    slot: 0,
+                    write_version: 0,
+                },
+            ])
+            .on_conflict_do_nothing()
+            .execute(&conn)
+            .expect("failed to seed metadata_jsons");
+
+        pool
+    }
+
+    lazy_static::lazy_static! {
+        pub static ref DATABASE: super::Pool = initialize();
+    }
+}

--- a/crates/core/src/db/queries/collections.rs
+++ b/crates/core/src/db/queries/collections.rs
@@ -67,6 +67,8 @@ fn make_by_volume_query_string(order_direction: OrderDirection) -> String {
             metadatas.slot,
             metadata_jsons.description,
             metadata_jsons.image,
+            metadata_jsons.animation_url,
+            metadata_jsons.external_url,
             metadata_jsons.category,
             metadata_jsons.model
         FROM metadata_jsons, volume_table, metadatas
@@ -150,6 +152,8 @@ fn make_by_market_cap_query_string(order_direction: OrderDirection) -> String {
             metadatas.slot,
             metadata_jsons.description,
             metadata_jsons.image,
+            metadata_jsons.animation_url,
+            metadata_jsons.external_url,
             metadata_jsons.category,
             metadata_jsons.model
         FROM metadatas
@@ -162,4 +166,47 @@ fn make_by_market_cap_query_string(order_direction: OrderDirection) -> String {
     -- $5: offset::integer",
         order_direction = order_direction
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use crate::db::test::DATABASE;
+
+    #[test]
+    fn test_collections_featured_by_marketcap_returns_non_empty() {
+        let pool = &DATABASE;
+
+        let result = super::by_market_cap(
+            &pool.get().expect("failed to aquire database connection"),
+            None::<Vec<String>>,
+            crate::db::custom_types::OrderDirection::Desc,
+            Utc.ymd(1901, 1, 1).and_hms(0, 0, 0),
+            Utc.ymd(3000, 1, 1).and_hms(0, 0, 0),
+            50,
+            0,
+        )
+        .expect("failed query");
+
+        assert!(!result.is_empty(), "expected at least one row");
+    }
+
+    #[test]
+    fn test_collections_featured_by_volume_returns_non_empty() {
+        let pool = &DATABASE;
+
+        let result = super::by_volume(
+            &pool.get().expect("failed to aquire database connection"),
+            None::<Vec<String>>,
+            crate::db::custom_types::OrderDirection::Desc,
+            Utc.ymd(1901, 1, 1).and_hms(0, 0, 0),
+            Utc.ymd(3000, 1, 1).and_hms(0, 0, 0),
+            50,
+            0,
+        )
+        .expect("failed query");
+
+        assert!(!result.is_empty(), "expected at least one row");
+    }
 }

--- a/crates/core/src/db/queries/nft_count.rs
+++ b/crates/core/src/db/queries/nft_count.rs
@@ -305,3 +305,19 @@ pub fn store_creators(
         .load(conn)
         .context("Failed to load store creators counts")
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::db::test::DATABASE;
+
+    #[test]
+    fn test_store_creators_minimal_passes() {
+        let pool = &DATABASE;
+
+        let _ = super::store_creators(
+            &pool.get().expect("failed to aquire database connection"),
+            Vec::<String>::new(),
+        )
+        .expect("failed query");
+    }
+}


### PR DESCRIPTION
This PR adds initial setup for running tests against DB queries. Right now it's primarily testing the collections queries. This will ensure that if fields required for deserialing `Nft` change, the build will fail.