### PR TITLE
Allow for filtering solely by update_authority

### DIFF
--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -379,6 +379,7 @@ impl QueryRoot {
             && auction_houses.is_none()
             && offerers.is_none()
             && term.is_none()
+            && update_authorities.is_none()
         {
             return Err(FieldError::new(
                 "No filter provided! Please provide at least one of the following arguments",
@@ -388,7 +389,8 @@ impl QueryRoot {
                     "creators",
                     "auction_houses",
                     "offerers",
-                    "term"
+                    "term",
+                    "update_authorities"
                 ]),
             ));
         }


### PR DESCRIPTION
## Problem: 
Dan: I'd like to filter nfts by update_authorities. At the moment, owners or creators is required. I think this might have initially been done to prevent unchecked queries returning large datasets. 

Solution: Remove / modify check that requires owners or creators from the nfts query.

This query should work:

```{
  nfts(
    updateAuthorities: ["3qaRhSRP2vHGNR83FPXqtjBWT9gv1Bkrq9hrRkyBmw58"],
     limit: 10000, offset: 0) {
    name
    mintAddress
    address

    files {
      uri
      fileType
    }
  }
}
```

Right now it returns this error:

```{
  "data": null,
  "errors": [
    {
      "message": "No filter provided! Please provide at least one of the filters",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "nfts"
      ],
      "extensions": {
        "Filters": "owners: Vec<PublicKey>, creators: Vec<PublicKey>, offerers: Vec<PublicKey>, auction_houses: Vec<PublicKey>, term: String"
      }
    }
  ]
}
```

## Solution

Add update_authority to the && check in query root.