### PR TITLE
remove auction house dataloader

### DIFF
--- a/crates/graphql/src/schema/objects/ah_listing.rs
+++ b/crates/graphql/src/schema/objects/ah_listing.rs
@@ -38,6 +38,10 @@ impl AhListing {
         &self.metadata
     }
 
+    fn auction_house(&self) -> &PublicKey<AuctionHouse> {
+        &self.auction_house
+    }
+
     fn purchase_id(&self) -> Option<Uuid> {
         self.purchase_id
     }
@@ -65,14 +69,6 @@ impl AhListing {
     pub async fn nft(&self, ctx: &AppContext) -> FieldResult<Option<Nft>> {
         ctx.nft_loader
             .load(self.metadata.clone())
-            .await
-            .map_err(Into::into)
-    }
-
-    pub async fn auction_house(&self, context: &AppContext) -> FieldResult<Option<AuctionHouse>> {
-        context
-            .store_auction_houses_loader
-            .load(self.auction_house.clone())
             .await
             .map_err(Into::into)
     }

--- a/crates/graphql/src/schema/objects/ah_offer.rs
+++ b/crates/graphql/src/schema/objects/ah_offer.rs
@@ -39,6 +39,10 @@ impl Offer {
         &self.metadata
     }
 
+    fn auction_house(&self) -> &PublicKey<AuctionHouse> {
+        &self.auction_house
+    }
+
     fn price(&self) -> U64 {
         self.price
     }
@@ -70,14 +74,6 @@ impl Offer {
     pub async fn nft(&self, ctx: &AppContext) -> FieldResult<Option<Nft>> {
         ctx.nft_loader
             .load(self.metadata.clone())
-            .await
-            .map_err(Into::into)
-    }
-
-    pub async fn auction_house(&self, context: &AppContext) -> FieldResult<Option<AuctionHouse>> {
-        context
-            .store_auction_houses_loader
-            .load(self.auction_house.clone())
             .await
             .map_err(Into::into)
     }

--- a/crates/graphql/src/schema/objects/ah_purchase.rs
+++ b/crates/graphql/src/schema/objects/ah_purchase.rs
@@ -35,6 +35,10 @@ impl Purchase {
         &self.metadata
     }
 
+    fn auction_house(&self) -> &PublicKey<AuctionHouse> {
+        &self.auction_house
+    }
+
     fn price(&self) -> U64 {
         self.price
     }
@@ -50,14 +54,6 @@ impl Purchase {
     pub async fn nft(&self, ctx: &AppContext) -> FieldResult<Option<Nft>> {
         ctx.nft_loader
             .load(self.metadata.clone())
-            .await
-            .map_err(Into::into)
-    }
-
-    pub async fn auction_house(&self, context: &AppContext) -> FieldResult<Option<AuctionHouse>> {
-        context
-            .store_auction_houses_loader
-            .load(self.auction_house.clone())
             .await
             .map_err(Into::into)
     }

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -281,12 +281,8 @@ impl NftActivity {
             .map_err(Into::into)
     }
 
-    pub async fn auction_house(&self, context: &AppContext) -> FieldResult<Option<AuctionHouse>> {
-        context
-            .store_auction_houses_loader
-            .load(self.auction_house.clone())
-            .await
-            .map_err(Into::into)
+    fn auction_house(&self) -> &PublicKey<AuctionHouse> {
+        &self.auction_house
     }
 }
 


### PR DESCRIPTION
MagicEden auctionhouse data is not indexed in auction_houses table so this dataloader is removed to expose the auction house field for offers, listing, purchases and Nft activity for other marketplaces