### PR TITLE
fix key used to look up stats for collections

### DIFF
--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -540,7 +540,7 @@ impl Collection {
     async fn nft_count(&self, context: &AppContext) -> FieldResult<Option<scalars::I64>> {
         Ok(context
             .collection_nft_count_loader
-            .load(self.0.address.clone().into())
+            .load(self.0.mint_address.clone().into())
             .await?
             .map(|dataloaders::collection::CollectionNftCount(nft_count)| nft_count))
     }
@@ -548,7 +548,7 @@ impl Collection {
     async fn floor_price(&self, context: &AppContext) -> FieldResult<Option<scalars::I64>> {
         Ok(context
             .collection_floor_price_loader
-            .load(self.0.address.clone().into())
+            .load(self.0.mint_address.clone().into())
             .await?
             .map(|dataloaders::collection::CollectionFloorPrice(floor_price)| floor_price))
     }


### PR DESCRIPTION
This changes the key used for loading from the `collection_stats` table to use the NFT mint address instead of the metadata address