### PR TITLE
#630: only do collection stats migrations if needed

### DIFF
--- a/crates/core/migrations/2022-07-22-160735_add_collection_stats_table/up.sql
+++ b/crates/core/migrations/2022-07-22-160735_add_collection_stats_table/up.sql
@@ -1,4 +1,4 @@
-create table collection_stats (
+create table if not exists collection_stats (
   collection_address  varchar(48) primary key,
   nft_count           bigint      not null,
   floor_price         bigint      null

--- a/crates/core/migrations/2022-07-22-161104_collection_stats_backfill/up.sql
+++ b/crates/core/migrations/2022-07-22-161104_collection_stats_backfill/up.sql
@@ -12,8 +12,7 @@ with
             metadata_collection_keys.collection_address as collection_address,
             count(metadata_collection_keys.metadata_address) as nft_count
         from metadata_collection_keys
-        where 
-            metadata_collection_keys.verified = true
+        where metadata_collection_keys.verified = true
         group by metadata_collection_keys.collection_address
     ),
 

--- a/crates/core/migrations/2022-07-22-161901_update_nft_counts_on_collection_stats_hook/up.sql
+++ b/crates/core/migrations/2022-07-22-161901_update_nft_counts_on_collection_stats_hook/up.sql
@@ -11,6 +11,8 @@ begin
 end
 $$;
 
+drop trigger if exists nft_collection_key_added on metadata_collection_keys;
+
 create trigger nft_collection_key_added
 after insert on metadata_collection_keys for each row
 execute procedure nft_count_on_nft_added();

--- a/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/up.sql
+++ b/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/up.sql
@@ -32,6 +32,9 @@ begin
 end
 $$;
 
+drop trigger if exists listing_added on listings;
+drop trigger if exists listing_updated on listings;
+
 create trigger listing_added
 after insert on listings for each row
 execute procedure floor_price_on_listing_update();


### PR DESCRIPTION
This adds a condition to only do the `collection_stats` migrations if it hasnt been run before (by checking that there are >0 rows in the table). This way we can run the backfill manually before deploying prod to prevent this potentially long-running migration