### PR TITLE
return listings < 3 days old

### DIFF
--- a/crates/core/src/db/queries/featured_listings.rs
+++ b/crates/core/src/db/queries/featured_listings.rs
@@ -49,6 +49,7 @@ FROM (
         AND listings.purchase_id IS NULL
         AND listings.canceled_at IS NULL
         AND listings.auction_house = ANY($1)
+        AND listings.created_at > current_date - interval '3 day'
         AND (($2 IS NULL) OR NOT(listings.seller = ANY($2)))
 
     GROUP BY listings.metadata, listings.id


### PR DESCRIPTION
This PR aims to make the holaplex homepage more dynamic by only returning newer listings from popular creators.