### PR TITLE
add migration to fix collection floor price update trigger

### DIFF
--- a/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/down.sql
+++ b/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/down.sql
@@ -1,1 +1,3 @@
-SELECT FALSE;
+drop trigger listing_added on listings;
+drop trigger listing_updated on listings;
+drop function floor_price_on_listing_update();

--- a/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/down.sql
+++ b/crates/core/migrations/2022-07-22-171755_update_floor_price_on_collection_stats_hook/down.sql
@@ -1,3 +1,1 @@
-drop trigger listing_added on listings;
-drop trigger listing_updated on listings;
-drop function floor_price_on_listing_update();
+SELECT FALSE;

--- a/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/down.sql
+++ b/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/down.sql
@@ -1,3 +1,1 @@
-drop trigger listing_added on listings;
-drop trigger listing_updated on listings;
-drop function floor_price_on_listing_update();
+SELECT FALSE;

--- a/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/down.sql
+++ b/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/down.sql
@@ -1,0 +1,3 @@
+drop trigger listing_added on listings;
+drop trigger listing_updated on listings;
+drop function floor_price_on_listing_update();

--- a/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/up.sql
+++ b/crates/core/migrations/2022-08-05-172611_fix_update_floor_price_on_collection_stats_hook/up.sql
@@ -1,0 +1,44 @@
+create or replace function floor_price_on_listing_update() returns trigger
+  language plpgsql
+  as $$
+begin
+  insert into collection_stats (collection_address, nft_count, floor_price)
+  select
+      metadata_collection_keys.collection_address as collection_address,
+      0 as nft_count,
+      min(listings.price) as floor_price
+  from listings
+  inner join metadatas on (listings.metadata = metadatas.address)
+  inner join metadata_collection_keys
+      on (metadatas.address = metadata_collection_keys.metadata_address)
+  inner join auction_houses
+      on (listings.auction_house = auction_houses.address)
+  where metadata_collection_keys.collection_address = (
+  	select collection_address 
+    from metadata_collection_keys 
+    where metadata_address = new.metadata
+  )
+      and auction_houses.treasury_mint =
+          'So11111111111111111111111111111111111111112'
+      and listings.purchase_id is null
+      and listings.canceled_at is null
+      and metadata_collection_keys.verified = true
+  group by metadata_collection_keys.collection_address
+
+  on conflict (collection_address)
+  do update set floor_price = excluded.floor_price;
+
+  return null;
+end
+$$;
+
+drop trigger if exists listing_added on listings;
+drop trigger if exists listing_updated on listings;
+
+create trigger listing_added
+after insert on listings for each row
+execute procedure floor_price_on_listing_update();
+
+create trigger listing_updated
+after update on listings for each row
+execute procedure floor_price_on_listing_update();


### PR DESCRIPTION
This PR makes an adjustment to the trigger used to update collection floor price on listing add/change. It creates a new migration similar to the old one, and drops the old trigger before creating the new one.