### PR TITLE
use compound key for candy machine creators

### DIFF
--- a/crates/core/migrations/2022-08-15-172917_add_compound_key_to_candymachine_creators/down.sql
+++ b/crates/core/migrations/2022-08-15-172917_add_compound_key_to_candymachine_creators/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+alter table candy_machine_creators
+drop constraint candy_machine_creators_compound_pkey,
+add constraint candy_machine_creators_pkey primary key (candy_machine_creators_compound_pkey);

--- a/crates/core/migrations/2022-08-15-172917_add_compound_key_to_candymachine_creators/up.sql
+++ b/crates/core/migrations/2022-08-15-172917_add_compound_key_to_candymachine_creators/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+alter table candy_machine_creators
+drop constraint candy_machine_creators_pkey,
+add constraint candy_machine_creators_compound_pkey primary key (candy_machine_address, creator_address);

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -215,7 +215,7 @@ table! {
     use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
     use crate::db::custom_types::{ListingEventLifecycle as Listingeventlifecycle, Mode, ProposalState as Proposalstate, InstructionExecutionFlags as Instructionexecutionflags, ProposalVoteType as Proposalvotetype, OptionVoteResult as Optionvoteresult, MintMaxVoteType as Mintmaxvotetype, VoteTipping as Votetipping, VoteRecordV2Vote as Vote_record_v2_vote, VoteThresholdType as Votethresholdtype, GovernanceAccountType as Governanceaccounttype, TransactionExecutionStatus as Transactionexecutionstatus, OfferEventLifecycle as Offereventlifecycle, SettingType as Settingtype, TokenStandard as Token_standard, };
 
-    candy_machine_creators (candy_machine_address) {
+    candy_machine_creators (candy_machine_address, creator_address) {
         candy_machine_address -> Varchar,
         creator_address -> Varchar,
         verified -> Bool,

--- a/crates/indexer/src/geyser/accounts/candy_machine.rs
+++ b/crates/indexer/src/geyser/accounts/candy_machine.rs
@@ -123,7 +123,10 @@ async fn process_creators(client: &Client, key: Pubkey, creators: Vec<Creator>) 
             .run(move |db| {
                 insert_into(candy_machine_creators::table)
                     .values(&c)
-                    .on_conflict(candy_machine_creators::candy_machine_address)
+                    .on_conflict((
+                        candy_machine_creators::candy_machine_address,
+                        candy_machine_creators::creator_address,
+                    ))
                     .do_update()
                     .set(&c)
                     .execute(db)


### PR DESCRIPTION
Candy machines can have multiple, so using the candy_machine_address alone as the primary key doesn't work. This changes the table to use a compound primary key of `(candy_machine_address, creator_address)`