### PR TITLE
Collection Activity By Mint Address

### DIFF
--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -547,7 +547,7 @@ impl Collection {
         let conn = ctx.shared.db.get()?;
         let rows = queries::collections::collection_activities(
             &conn,
-            &self.0.address,
+            &self.0.mint_address,
             event_types,
             limit,
             offset,


### PR DESCRIPTION
### Fix
- Filter NFTs for collection activity based on the mint address of the collection nft this is what is set on the collection_metadata_keys