### PR TITLE
dao-marketplace/#45: collection stats

### DIFF
--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -596,11 +596,24 @@ impl Collection {
     }
 
     #[graphql(
-        description = "Total of all sales of all NFTs in the collection over all time, in lamports."
+        description = "Total of all sales of all NFTs in the collection over all time, in lamports.",
+        arguments(
+            start_date(
+                description = "Compute volume over purchases made later than this date (ISO 8601 format like 2022-07-04T17:06:10Z)"
+            ),
+            end_date(
+                description = "Compute volume over purchases made earlier than this date (ISO 8601 format like 2022-07-04T17:06:10Z)"
+            )
+        )
     )]
-    pub async fn volume_total(&self, ctx: &AppContext) -> FieldResult<scalars::I64> {
+    pub async fn volume_total(
+        &self,
+        ctx: &AppContext,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+    ) -> FieldResult<scalars::I64> {
         let conn = ctx.shared.db.get()?;
-        queries::collections::volume_total(&conn, self.0.mint_address.clone())
+        queries::collections::volume_total(&conn, self.0.mint_address.clone(), start_date, end_date)
             .map(Into::into)
             .map_err(Into::into)
     }

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -559,6 +559,31 @@ impl Collection {
             .map_err(Into::into)
     }
 
+    #[graphql(description = "Lowest price of currently listed NFTs in the collection.")]
+    async fn floor_price(&self, context: &AppContext) -> FieldResult<Option<scalars::I64>> {
+        Ok(context
+            .collection_floor_price_loader
+            .load(self.0.mint_address.clone().into())
+            .await?
+            .map(|dataloaders::collection::CollectionFloorPrice(floor_price)| floor_price))
+    }
+
+    #[graphql(
+        description = "Count of wallets that currently hold at least one NFT from the collection."
+    )]
+    pub async fn holder_count(&self, ctx: &AppContext) -> FieldResult<scalars::I64> {
+        Ok(scalars::I64::from(0))
+    }
+
+    #[graphql(description = "Count of active listings of NFTs in the collection.")]
+    pub async fn listed_count(&self, ctx: &AppContext) -> FieldResult<scalars::I64> {
+        let conn = ctx.shared.db.get()?;
+        queries::collections::listed_count(&conn, self.0.mint_address.clone())
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    #[graphql(description = "Count of NFTs in the collection.")]
     async fn nft_count(&self, context: &AppContext) -> FieldResult<Option<scalars::I64>> {
         Ok(context
             .collection_nft_count_loader
@@ -567,12 +592,11 @@ impl Collection {
             .map(|dataloaders::collection::CollectionNftCount(nft_count)| nft_count))
     }
 
-    async fn floor_price(&self, context: &AppContext) -> FieldResult<Option<scalars::I64>> {
-        Ok(context
-            .collection_floor_price_loader
-            .load(self.0.mint_address.clone().into())
-            .await?
-            .map(|dataloaders::collection::CollectionFloorPrice(floor_price)| floor_price))
+    #[graphql(
+        description = "Total of all sales of all NFTs in the collection over all time, in lamports."
+    )]
+    pub async fn volume_total(&self, ctx: &AppContext) -> FieldResult<Option<scalars::I64>> {
+        Ok(Some(scalars::I64::from(0)))
     }
 
     #[graphql(deprecated = "use `nft { address }`")]

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -572,7 +572,10 @@ impl Collection {
         description = "Count of wallets that currently hold at least one NFT from the collection."
     )]
     pub async fn holder_count(&self, ctx: &AppContext) -> FieldResult<scalars::I64> {
-        Ok(scalars::I64::from(0))
+        let conn = ctx.shared.db.get()?;
+        queries::collections::holder_count(&conn, self.0.mint_address.clone())
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     #[graphql(description = "Count of active listings of NFTs in the collection.")]
@@ -595,8 +598,11 @@ impl Collection {
     #[graphql(
         description = "Total of all sales of all NFTs in the collection over all time, in lamports."
     )]
-    pub async fn volume_total(&self, ctx: &AppContext) -> FieldResult<Option<scalars::I64>> {
-        Ok(Some(scalars::I64::from(0)))
+    pub async fn volume_total(&self, ctx: &AppContext) -> FieldResult<scalars::I64> {
+        let conn = ctx.shared.db.get()?;
+        queries::collections::volume_total(&conn, self.0.mint_address.clone())
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     #[graphql(deprecated = "use `nft { address }`")]


### PR DESCRIPTION
This PR adds three new fields to the `Collection` object to support collection display in the marketplace.

# Changes
- added query and field for total volume of sales, with time range args (`collections.rs`, `nft.rs`)
- added query and field for count of current holders of collection NFTs, which throws an error if the collection isnt found (`collections.rs`, `nft.rs`)
- added query and field for count of active listings of collection NFTs, which throws an error if the collection isnt found (`collections.rs`, `nft.rs`)