### PR TITLE
Fix Top Marketcap Query

### DIFF
--- a/crates/graphql/src/schema/context.rs
+++ b/crates/graphql/src/schema/context.rs
@@ -120,7 +120,6 @@ impl AppContext {
 
         Self {
             shared,
-
             ah_listing_loader: Loader::new(batcher.clone()),
             ah_listings_loader: Loader::new(batcher.clone()),
             auction_house_loader: Loader::new(batcher.clone()),
@@ -176,7 +175,6 @@ impl AppContext {
             store_creator_loader: Loader::new(batcher.clone()),
             storefront_loader: Loader::new(batcher.clone()),
             twitter_handle_loader: Loader::new(batcher),
-
             twitter_profile_loader: Loader::new(twitter_batcher),
         }
     }


### PR DESCRIPTION
### Issue
Tops marketcap query throwing bigint overflow error from postgres while counting nfts belonging to a collection.

### Fix
- Use collection_stats to get the total number of nfts belonging to the collection.
- Only use listings from ME