### PR TITLE
[HotFix] Do Nothing on Config line conflict

### DIFF
--- a/crates/indexer/src/geyser/accounts/candy_machine.rs
+++ b/crates/indexer/src/geyser/accounts/candy_machine.rs
@@ -111,12 +111,7 @@ async fn process_config_lines(
                 for cl in &db_config_lines {
                     insert_into(candy_machine_config_lines::table)
                         .values(cl)
-                        .on_conflict((
-                            candy_machine_config_lines::candy_machine_address,
-                            candy_machine_config_lines::idx,
-                        ))
-                        .do_update()
-                        .set(cl)
+                        .on_conflict_do_nothing()
                         .execute(db)
                         .context("Failed to insert config line")?;
                 }


### PR DESCRIPTION
### Issue
The db is locking from row conflict when indexing candy machine config lines on startup and we have 2 validators issuing the same index at nearly the same time.

### Temp Fix
- Since CM config lines changes infrequently do nothing when there is a conflict for the time being