### PR TITLE
[Fix] Collected Collections Query

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -1097,10 +1097,10 @@ pub struct TwitterHandle<'a> {
 
 /// A row in a `collected_collections` query of a wallet
 #[derive(Debug, Clone, QueryableByName)]
-pub struct CollectedCollection<'a> {
-    /// The collection for which data is collected
+pub struct CollectedCollection {
+    /// The collection nft metadadata address
     #[sql_type = "VarChar"]
-    pub collection: Cow<'a, str>,
+    pub collection_nft_address: String,
     /// The nfts from this collection owned by the wallet
     #[sql_type = "Int8"]
     pub nfts_owned: i64,

--- a/crates/core/src/db/queries/wallet.rs
+++ b/crates/core/src/db/queries/wallet.rs
@@ -84,8 +84,7 @@ pub fn activities(
 }
 
 const COLLECTED_COLLECTIONS_QUERY: &str = r"
-SELECT
-    metadata_collection_keys.collection_address as collection,
+SELECT collection_metadatas.address as collection_nft_address,
 	COUNT(metadatas.address) as nfts_owned,
 	COALESCE(collection_stats.floor_price * COUNT(metadatas.address), 0) as estimated_value
     FROM metadatas
@@ -97,7 +96,7 @@ SELECT
 	INNER JOIN metadata_jsons collection_metadata_jsons ON (collection_metadata_jsons.metadata_address = collection_metadatas.address)
     WHERE current_metadata_owners.owner_address = $1
     AND metadata_collection_keys.verified
-    GROUP BY metadata_collection_keys.collection_address, collection_stats.floor_price
+    GROUP BY collection_nft_address, collection_stats.floor_price
 	ORDER BY estimated_value DESC;
     -- $1: address::text";
 

--- a/crates/graphql/src/schema/objects/wallet.rs
+++ b/crates/graphql/src/schema/objects/wallet.rs
@@ -124,23 +124,23 @@ impl WalletNftCount {
 
 #[derive(Debug, Clone)]
 pub struct CollectedCollection {
-    collection: PublicKey<Nft>,
+    metadata_address: PublicKey<Nft>,
     nfts_owned: i32,
     estimated_value: U64,
 }
 
-impl<'a> TryFrom<models::CollectedCollection<'a>> for CollectedCollection {
+impl TryFrom<models::CollectedCollection> for CollectedCollection {
     type Error = std::num::TryFromIntError;
 
     fn try_from(
         models::CollectedCollection {
-            collection,
+            collection_nft_address,
             nfts_owned,
             estimated_value,
         }: models::CollectedCollection,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            collection: collection.into(),
+            metadata_address: collection_nft_address.into(),
             nfts_owned: nfts_owned.try_into()?,
             estimated_value: estimated_value.try_into()?,
         })
@@ -151,7 +151,7 @@ impl<'a> TryFrom<models::CollectedCollection<'a>> for CollectedCollection {
 impl CollectedCollection {
     async fn collection(&self, ctx: &AppContext) -> FieldResult<Option<Collection>> {
         ctx.nft_loader
-            .load(self.collection.clone())
+            .load(self.metadata_address.clone())
             .await
             .map(|op| op.map(Into::into))
             .map_err(Into::into)


### PR DESCRIPTION
### Issue
The collected collections was using the mint address for the nft dataloader when it needed to be the nft metadata address.