### PR TITLE
forward all metadatas request through imgopt

### DIFF
--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -353,7 +353,23 @@ mod cdn {
 
         Ok(url)
     }
+    /// Get the proxy URL parameters for non-permaweb assets
+    ///
+    /// # Errors
+    /// This function fails if the asset proxy configured by `args` has an
+    /// invalid URL
 
+    #[inline]
+    pub fn proxy_non_permaweb_url(
+        args: &AssetProxyArgs,
+        endpoint: impl AsRef<str>,
+    ) -> Result<Url> {
+        let mut url = Url::parse(&args.asset_proxy_endpoint.replace("[n]", ""))
+            .context("Invalid asset proxy URL")?;
+        url.query_pairs_mut()
+        .append_pair("url", endpoint.as_ref());
+        Ok(url)
+    }
     /// Format an [`AssetIdentifier`] as an Holaplex asset proxy URL.  Returns
     /// `None` if the ID was unparseable or ambiguous.
     ///

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Display};
 
 use indexer_core::{
-    assets::{proxy_url, proxy_url_hinted, AssetIdentifier},
+    assets::{proxy_url, proxy_url_hinted, proxy_non_permaweb_url, AssetIdentifier},
     db::{
         delete, insert_into,
         models::{
@@ -214,7 +214,7 @@ async fn try_locate_json(
             proxy_url_hinted(client.proxy_args(), id, hint, None)
                 .map(|u| u.unwrap_or_else(|| unreachable!()))
         } else if FETCH_NON_PERMAWEB {
-            Ok(id.url.clone())
+            Ok(proxy_non_permaweb_url(client.proxy_args(), id.url.clone())?)
         } else {
             continue;
         };


### PR DESCRIPTION
support for non-permaweb endpoints has been added to `imgopt` (see [PR](https://github.com/holaplex/imgopt/pull/10)). 
this PR is required to forward *all* metadatas requests through the assets endpoint
