### PR TITLE
Collection Queries Repalce Magic Eden ID with ID

### DIFF
--- a/crates/core/src/db/queries/collections.rs
+++ b/crates/core/src/db/queries/collections.rs
@@ -90,7 +90,7 @@ enum DolphinStats {
 #[allow(missing_docs)]
 enum Collections {
     Table,
-    MagicEdenId,
+    Id,
 }
 
 /// Query collection by address
@@ -575,7 +575,7 @@ pub fn trends(conn: &Connection, options: TrendingQueryOptions) -> Result<Vec<Do
         .from(DolphinStats::Table)
         .inner_join(
             Collections::Table,
-            Expr::tbl(Collections::Table, Collections::MagicEdenId)
+            Expr::tbl(Collections::Table, Collections::Id)
                 .equals(DolphinStats::Table, DolphinStats::CollectionSymbol),
         )
         .limit(limit)

--- a/crates/core/src/db/queries/wallet.rs
+++ b/crates/core/src/db/queries/wallet.rs
@@ -145,7 +145,7 @@ SELECT collections.id as collection_id,
 	INNER JOIN metadatas ON (metadatas.mint_address = collection_mints.mint)
     INNER JOIN current_metadata_owners ON (current_metadata_owners.mint_address = metadatas.mint_address)
     INNER JOIN metadata_jsons ON (metadata_jsons.metadata_address = metadatas.address)
-    INNER JOIN dolphin_stats ON (dolphin_stats.collection_symbol = collections.magic_eden_id)
+    INNER JOIN dolphin_stats ON (dolphin_stats.collection_symbol = collections.id)
     WHERE current_metadata_owners.owner_address = $1
     GROUP BY collections.id, dolphin_stats.floor_1d
 	ORDER BY estimated_value DESC;

--- a/crates/graphql/src/schema/objects/collection.rs
+++ b/crates/graphql/src/schema/objects/collection.rs
@@ -187,14 +187,9 @@ impl Collection {
     }
 
     pub async fn trends(&self, context: &AppContext) -> FieldResult<Option<CollectionTrend>> {
-        let magic_eden_id = match self.magic_eden_id {
-            Some(ref id) => id.clone(),
-            None => return Ok(None),
-        };
-
         context
             .mr_collection_trends_loader
-            .load(magic_eden_id)
+            .load(self.id.clone())
             .await
             .map_err(Into::into)
     }


### PR DESCRIPTION
### Fix
magic_eden_id has some duplicates and is the same as collection id so swap to that for all the queries.